### PR TITLE
Use service name in IAM role so name is unique within the account

### DIFF
--- a/AcademyResidentInformationApi/serverless.yml
+++ b/AcademyResidentInformationApi/serverless.yml
@@ -29,7 +29,7 @@ resources:
       Type: AWS::IAM::Role
       Properties:
         Path: /${self:service}/${self:provider.stage}/
-        RoleName: lambdaExecutionRole
+        RoleName: ${self:service}-lambdaExecutionRole
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:


### PR DESCRIPTION
Because the mosaic role name was the same it was causing a conflict