### PR TITLE
Add Dockerfile for test database

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:12
+
+COPY ./database/schema.sql ./docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,10 +33,11 @@ services:
     links:
       - test-database
   test-database:
-    image: postgres:12
+    image: test-database
+    build:
+      context: .
+      dockerfile: database/Dockerfile
     ports:
       - 5432:5432
     env_file:
       - database.env
-    volumes:
-      - ./database:/docker-entrypoint-initdb.d


### PR DESCRIPTION
Volumes can't be mounted to a remote docker image in circle CI. They can however be copied, so have created a dockerfile for the test database separately.