### PR TITLE
Updated endpoint with new path as specified on ticket, tests updated

### DIFF
--- a/AcademyResidentInformationApi.Tests/AcademyResidentInformationApi.Tests.csproj
+++ b/AcademyResidentInformationApi.Tests/AcademyResidentInformationApi.Tests.csproj
@@ -7,6 +7,7 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/AcademyResidentInformationApi.Tests/V1/Controllers/AcademyControllerTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Controllers/AcademyControllerTests.cs
@@ -65,10 +65,8 @@ namespace AcademyResidentInformationApi.Tests.V1.Controllers
                 DateOfBirth = "01/01/2020"
             };
 
-            var testAcademyId = "5678-1234";
-
-            _mockGetClaimantByIdUseCase.Setup(x => x.Execute(testAcademyId)).Returns(singleClaimantInfo);
-            var response = _classUnderTest.ViewRecord(testAcademyId) as OkObjectResult;
+            _mockGetClaimantByIdUseCase.Setup(x => x.Execute(123, 456)).Returns(singleClaimantInfo);
+            var response = _classUnderTest.ViewRecord(123, 456) as OkObjectResult;
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(200);

--- a/AcademyResidentInformationApi.Tests/V1/E2ETests/GetClaimantInformationById.cs
+++ b/AcademyResidentInformationApi.Tests/V1/E2ETests/GetClaimantInformationById.cs
@@ -27,7 +27,7 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
             var academyId = $"{claimId}-{personRef}";
             var expectedResponse = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, academyId);
 
-            var requestUri = new Uri($"api/v1/claimants/{academyId}", UriKind.Relative);
+            var requestUri = new Uri($"/claims/{claimId}/person/{personRef}", UriKind.Relative);
             var response = Client.GetAsync(requestUri);
             var statusCode = response.Result.StatusCode;
             statusCode.Should().Be(200);
@@ -37,6 +37,15 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
             var convertedResponse = JsonConvert.DeserializeObject<ClaimantInformation>(stringContent);
 
             convertedResponse.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
+        public void GetClaimantInformationByIdReturns404NotFound()
+        {
+            var requestUri = new Uri($"/claims/0/househould/0/members/0", UriKind.Relative);
+            var response = Client.GetAsync(requestUri);
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(404);
         }
     }
 }

--- a/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyGatewayTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyGatewayTests.cs
@@ -280,6 +280,9 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             return databaseEntity;
         }
 
+        //Composite AcademyId key.
+        /*AcademyId is not a column in the DB but rather a string made up of the
+        claimId and personRef*/
         private static int ExtractClaimIdFromAcademyIdString(string academyId)
         {
             return int.Parse(academyId.Split('-').First());

--- a/AcademyResidentInformationApi.Tests/V1/UseCase/GetClaimantByIdUseCaseTest.cs
+++ b/AcademyResidentInformationApi.Tests/V1/UseCase/GetClaimantByIdUseCaseTest.cs
@@ -6,6 +6,8 @@ using AutoFixture;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using System;
+using ClaimantInformationResponse = AcademyResidentInformationApi.V1.Boundary.Responses.ClaimantInformation;
 
 namespace AcademyResidentInformationApi.Tests.V1.UseCase
 {
@@ -27,17 +29,29 @@ namespace AcademyResidentInformationApi.Tests.V1.UseCase
         public void ReturnsAClaimantInformationRecordForTheSpecifiedID()
         {
             var stubbedClaimantInfo = _fixture.Create<ClaimantInformation>();
-            var testAcademyId = "1234-5678";
 
             _mockAcademyGateway.Setup(x =>
                     x.GetClaimantById(1234, 5678))
                 .Returns(stubbedClaimantInfo);
 
-            var response = _classUnderTest.Execute(testAcademyId);
+            var response = _classUnderTest.Execute(1234, 5678);
             var expectedResponse = stubbedClaimantInfo.ToResponse();
 
             response.Should().NotBeNull();
             response.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
+        public void IfGatewayReturnsNullThrowNotFoundException()
+        {
+            ClaimantInformation nullResult = null;
+
+            _mockAcademyGateway.Setup(x =>
+                    x.GetClaimantById(It.IsAny<int>(), It.IsAny<int>()))
+                .Returns(nullResult);
+
+            Func<ClaimantInformationResponse> testDelegate = () => _classUnderTest.Execute(123, 456);
+            testDelegate.Should().Throw<ClaimantNotFoundException>();
         }
     }
 }

--- a/AcademyResidentInformationApi/V1/Controllers/AcademyController.cs
+++ b/AcademyResidentInformationApi/V1/Controllers/AcademyController.cs
@@ -36,10 +36,20 @@ namespace AcademyResidentInformationApi.V1.Controllers
         }
 
         [HttpGet]
-        [Route("{academyId}")]
-        public IActionResult ViewRecord(string academyId)
+        [Route("/claims/{claimId}/person/{personRef}")]
+        public IActionResult ViewRecord(int claimId, int personRef)
         {
-            return Ok(_getClaimantByIdUseCase.Execute(academyId));
+            try
+            {
+                var record = _getClaimantByIdUseCase.Execute(claimId, personRef);
+                return Ok(record);
+            }
+            catch (ClaimantNotFoundException)
+            {
+                //return a 404
+                return NotFound();
+            }
+
         }
 
 

--- a/AcademyResidentInformationApi/V1/Domain/ClaimantNotFoundException.cs
+++ b/AcademyResidentInformationApi/V1/Domain/ClaimantNotFoundException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace AcademyResidentInformationApi.V1.Domain
+{
+    public class ClaimantNotFoundException : Exception
+    {
+        public ClaimantNotFoundException() { }
+        public ClaimantNotFoundException(string message) : base(message)
+        { }
+    }
+}

--- a/AcademyResidentInformationApi/V1/UseCase/GetClaimantByIdUseCase.cs
+++ b/AcademyResidentInformationApi/V1/UseCase/GetClaimantByIdUseCase.cs
@@ -2,6 +2,7 @@ using AcademyResidentInformationApi.V1.Boundary.Responses;
 using AcademyResidentInformationApi.V1.Factories;
 using AcademyResidentInformationApi.V1.Gateways;
 using AcademyResidentInformationApi.V1.UseCase.Interfaces;
+using ClaimantNotFoundException = AcademyResidentInformationApi.V1.Domain.ClaimantNotFoundException;
 
 namespace AcademyResidentInformationApi.V1.UseCase
 {
@@ -12,13 +13,11 @@ namespace AcademyResidentInformationApi.V1.UseCase
         {
             _academyGateway = academyGateway;
         }
-        public ClaimantInformation Execute(string academyId)
+        public ClaimantInformation Execute(int claimId, int personRef)
         {
-            var compositeKeyArray = academyId.Split('-');
-            var claimId = int.Parse(compositeKeyArray[0]);
-            var personRef = int.Parse(compositeKeyArray[1]);
-
-            return _academyGateway.GetClaimantById(claimId, personRef).ToResponse();
+            var claimant = _academyGateway.GetClaimantById(claimId, personRef);
+            if (claimant == null) throw new ClaimantNotFoundException();
+            return claimant.ToResponse();
         }
     }
 }

--- a/AcademyResidentInformationApi/V1/UseCase/Interfaces/IGetClaimantByIdUseCase.cs
+++ b/AcademyResidentInformationApi/V1/UseCase/Interfaces/IGetClaimantByIdUseCase.cs
@@ -4,6 +4,6 @@ namespace AcademyResidentInformationApi.V1.UseCase.Interfaces
 {
     public interface IGetClaimantByIdUseCase
     {
-        ClaimantInformation Execute(string academyId);
+        ClaimantInformation Execute(int claimId, int personRef);
     }
 }


### PR DESCRIPTION
Extend E2E helper to accept claimid, houseid and memberid
Update database schema with composite primary key (claim_id, house_id, member_id)
404 error returned for null records