### PR TITLE
Create tables in the dbo  schema

### DIFF
--- a/AcademyResidentInformationApi/V1/Infrastructure/Address.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/Address.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AcademyResidentInformationApi.V1.Infrastructure
 {
-    [Table("hbhousehold")]
+    [Table("hbhousehold", Schema = "dbo")]
     public class Address
     {
         public Person Person { get; set; }

--- a/AcademyResidentInformationApi/V1/Infrastructure/Claim.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/Claim.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AcademyResidentInformationApi.V1.Infrastructure
 {
-    [Table("hbclaim")]
+    [Table("hbclaim", Schema = "dbo")]
     public class Claim
     {
         [Column("claim_id")]

--- a/AcademyResidentInformationApi/V1/Infrastructure/Person.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/Person.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace AcademyResidentInformationApi.V1.Infrastructure
 {
-    [Table("hbmember")]
+    [Table("hbmember", Schema = "dbo")]
     public class Person
     {
         [Column("claim_id")]

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,4 +1,6 @@
-CREATE TABLE hbhousehold (
+CREATE SCHEMA IF NOT EXISTS dbo;
+
+CREATE TABLE dbo.hbhousehold (
 	claim_id int NULL,
 	house_id smallint NULL,
 	last_upd int NULL,
@@ -36,7 +38,7 @@ CREATE TABLE hbhousehold (
 	CONSTRAINT PK_hbhousehold PRIMARY KEY (claim_id, house_id)
 );
 
-CREATE TABLE hbmember (
+CREATE TABLE dbo.hbmember (
 	claim_id int NULL,
 	house_id smallint NULL,
 	member_id smallint NULL,
@@ -101,8 +103,7 @@ CREATE TABLE hbmember (
 	CONSTRAINT UC_hbmember UNIQUE (claim_id, house_id)
 );
 
-CREATE TABLE hbclaim
-(
+CREATE TABLE dbo.hbclaim(
     division_id                 smallint,
     claim_id                    int,
     last_upd                    int,
@@ -315,7 +316,7 @@ CREATE TABLE hbclaim
     uc_dhp_start_date           timestamp
 );
 
-CREATE TABLE ctaccount (
+CREATE TABLE dbo.ctaccount (
 	division_id smallint NULL,
 	account_ref int NULL,
 	account_cd varchar(1) NULL,
@@ -360,7 +361,7 @@ CREATE TABLE ctaccount (
 	documerge_excl_ind smallint NULL
 );
 
-CREATE TABLE ctproperty (
+CREATE TABLE dbo.ctproperty (
 	division_id smallint NULL,
 	property_ref varchar(18) NULL,
 	fund_no smallint NULL,


### PR DESCRIPTION
The tables in the test db were being added to the default public schema, EF was looking for tables in the public schema.

In the academy mirror, the tables actually live in the dbo schema.