### PR TITLE
Only return person/ address records related to current addresses

### DIFF
--- a/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyGatewayTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyGatewayTests.cs
@@ -118,6 +118,21 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         }
 
         [Test]
+        public void GetAllClaimantsIfThereAreClaimantsWillOnlyReturnCurrentAddresses()
+        {
+            var toDate = "2020-03-31 00:00:00.0000000";
+            var oldPersonRecord = AddPersonRecordToDatabase();
+            var newPersonRecord = AddPersonRecordToDatabase(memberId: oldPersonRecord.MemberId, withClaim: false, id: oldPersonRecord.ClaimId);
+            var oldAddress = AddAddressToDatabase(oldPersonRecord.ClaimId, oldPersonRecord.HouseId, toDate: toDate);
+            var newAddress = AddAddressToDatabase(newPersonRecord.ClaimId, newPersonRecord.HouseId);
+
+
+            var listOfPersons = _classUnderTest.GetAllClaimants(0, 20);
+
+            listOfPersons.Should().BeEquivalentTo(newPersonRecord.ToDomain());
+        }
+
+        [Test]
         public void GetAllResidentsWithFirstNameQueryParameterReturnsMatchingResident()
         {
             var databaseEntity = AddPersonRecordToDatabase(firstname: "ciasom");
@@ -394,9 +409,9 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(0).ClaimId);
             peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(2).ClaimId);
         }
-        private Person AddPersonRecordToDatabase(string firstname = null, string lastname = null, int? id = null, bool withClaim = true)
+        private Person AddPersonRecordToDatabase(string firstname = null, string lastname = null, int? id = null, bool withClaim = true, int? memberId = null)
         {
-            var databaseEntity = TestHelper.CreateDatabasePersonEntity(firstname, lastname, id);
+            var databaseEntity = TestHelper.CreateDatabasePersonEntity(firstname, lastname, id, memberId);
             AcademyContext.Persons.Add(databaseEntity);
             AcademyContext.SaveChanges();
             if (withClaim)
@@ -407,9 +422,9 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             return databaseEntity;
         }
 
-        private Address AddAddressToDatabase(int? claimId, int? houseId, string address = null, string postcode = null)
+        private Address AddAddressToDatabase(int? claimId, int? houseId, string address = null, string postcode = null, string toDate = "2099-12-31 00:00:00.0000000")
         {
-            var addressEntity = TestHelper.CreateDatabaseAddressForPersonId(claimId, houseId, postcode, address);
+            var addressEntity = TestHelper.CreateDatabaseAddressForPersonId(claimId, houseId, postcode, address, toDate);
             AcademyContext.Addresses.Add(addressEntity);
             AcademyContext.SaveChanges();
             return addressEntity;

--- a/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -9,7 +9,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Helper
 {
     public static class TestHelper
     {
-        public static Person CreateDatabasePersonEntity(string firstname = null, string lastname = null, int? id = null)
+        public static Person CreateDatabasePersonEntity(string firstname = null, string lastname = null, int? id = null, int? memberId = null)
         {
             var faker = new Fixture();
             var fp = faker.Build<Person>()
@@ -20,16 +20,19 @@ namespace AcademyResidentInformationApi.Tests.V1.Helper
             fp.FirstName = firstname ?? fp.FirstName;
             fp.LastName = lastname ?? fp.LastName;
             fp.ClaimId = id ?? fp.ClaimId;
+            fp.MemberId = id ?? fp.MemberId;
             return fp;
         }
 
-        public static Address CreateDatabaseAddressForPersonId(int? claimId, int? houseId, string postcode = null, string address = null)
+        public static Address CreateDatabaseAddressForPersonId(int? claimId, int? houseId, string postcode = null,
+            string address = null, string toDate = "2099-12-31 00:00:00.0000000")
         {
             var faker = new Fixture();
 
             var fa = faker.Build<Address>()
                 .With(add => add.ClaimId, claimId)
                 .With(add => add.HouseId, houseId)
+                .With(add => add.ToDate, toDate)
                 .Without(add => add.Claim)
                 .Without(add => add.Person)
                 .Create();

--- a/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -9,7 +9,8 @@ namespace AcademyResidentInformationApi.Tests.V1.Helper
 {
     public static class TestHelper
     {
-        public static Person CreateDatabasePersonEntity(string firstname = null, string lastname = null, int? id = null, int? memberId = null)
+        public static Person CreateDatabasePersonEntity(string firstname = null, string lastname = null, int? id = null,
+            int? memberId = null, int? personRef = null, int? houseId = null)
         {
             var faker = new Fixture();
             var fp = faker.Build<Person>()
@@ -20,7 +21,9 @@ namespace AcademyResidentInformationApi.Tests.V1.Helper
             fp.FirstName = firstname ?? fp.FirstName;
             fp.LastName = lastname ?? fp.LastName;
             fp.ClaimId = id ?? fp.ClaimId;
-            fp.MemberId = id ?? fp.MemberId;
+            fp.MemberId = memberId ?? fp.MemberId;
+            fp.PersonRef = personRef ?? fp.PersonRef;
+            fp.HouseId = houseId ?? fp.HouseId;
             return fp;
         }
 

--- a/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
@@ -27,6 +27,7 @@ namespace AcademyResidentInformationApi.V1.Gateways
                 where string.IsNullOrEmpty(postcode) || a.PostCode.ToLower().Replace(" ", "").Equals(StripString(postcode))
                 where string.IsNullOrEmpty(firstname) || person.FirstName.ToLower().Replace(" ", "").Contains(StripString(firstname))
                 where string.IsNullOrEmpty(lastname) || person.LastName.ToLower().Replace(" ", "").Contains(StripString(lastname))
+                where a.ToDate == "2099-12-31 00:00:00.0000000"
                 orderby person.ClaimId, person.HouseId, person.MemberId
                 select new Person
                 {

--- a/AcademyResidentInformationApi/V1/Infrastructure/Address.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/Address.cs
@@ -36,5 +36,9 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
         [Column("post_code", TypeName = "varchar")]
         [MaxLength(10)]
         public string PostCode { get; set; }
+
+        [Column("to_date", TypeName = "varchar")]
+        [MaxLength(37)]
+        public string ToDate { get; set; }
     }
 }

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -5,7 +5,7 @@ CREATE TABLE dbo.hbhousehold (
 	house_id smallint NULL,
 	last_upd int NULL,
 	from_date timestamp NULL,
-	to_date timestamp NULL,
+	to_date varchar(37) NULL,
 	inc_supp_ind smallint NULL,
 	claim_type_ind smallint NULL,
 	addr1 varchar(35) NULL,


### PR DESCRIPTION
There is a separate record in hbmember and hbhoushold tables for each tenancy a person has for a property, meaning personal and address details are duplicated for each tenancy. Thi change will only return the records for which tenancies are currently in action.