### PR TITLE
Use a combination of the 3 member table keys for the pagination cursor

### DIFF
--- a/AcademyResidentInformationApi.Tests/V1/Controllers/AcademyControllerTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Controllers/AcademyControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using AcademyResidentInformationApi.V1.Boundary.Responses;
 using AcademyResidentInformationApi.V1.Controllers;
 using AcademyResidentInformationApi.V1.UseCase.Interfaces;
@@ -6,7 +7,9 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using AcademyResidentInformationApi.V1.Boundary.Requests;
+using AcademyResidentInformationApi.V1.Domain;
 using NUnit.Framework;
+using ClaimantInformation = AcademyResidentInformationApi.V1.Boundary.Responses.ClaimantInformation;
 
 namespace AcademyResidentInformationApi.Tests.V1.Controllers
 {
@@ -47,12 +50,25 @@ namespace AcademyResidentInformationApi.Tests.V1.Controllers
 
             var cqp = new ClaimantQueryParam();
 
-            _mockGetAllClaimantsUseCase.Setup(x => x.Execute(cqp, 0, 20)).Returns(claimantInformationList);
+            _mockGetAllClaimantsUseCase.Setup(x => x.Execute(cqp, null, 20)).Returns(claimantInformationList);
             var response = _classUnderTest.ListContacts(cqp) as OkObjectResult;
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(200);
             response.Value.Should().BeEquivalentTo(claimantInformationList);
+        }
+
+        [Test]
+        public void ListContactsReturns400IfUseCaseThrowsInvalidCursorException()
+        {
+            _mockGetAllClaimantsUseCase.Setup(x => x.Execute(It.IsAny<ClaimantQueryParam>(), null, 20))
+                .Throws(new InvalidCursorException("Wrong cursor"));
+
+            var response = _classUnderTest.ListContacts(new ClaimantQueryParam()) as BadRequestObjectResult;
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(400);
+            response.Value.Should().Be("Wrong cursor");
         }
 
         [Test]

--- a/AcademyResidentInformationApi.Tests/V1/Factories/EntityFactoryTest.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Factories/EntityFactoryTest.cs
@@ -21,7 +21,9 @@ namespace AcademyResidentInformationApi.Tests.V1.Factories
                 FirstName = personRecord.FirstName,
                 LastName = personRecord.LastName,
                 DateOfBirth = personRecord.DateOfBirth,
-                NINumber = personRecord.NINumber
+                NINumber = personRecord.NINumber,
+                HouseId = personRecord.HouseId.Value,
+                MemberId = personRecord.MemberId.Value,
             });
         }
 

--- a/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyGatewayTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyGatewayTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using AcademyResidentInformationApi.Tests.V1.Helper;
+using AcademyResidentInformationApi.V1.Domain;
 using AcademyResidentInformationApi.V1.Factories;
 using AcademyResidentInformationApi.V1.Gateways;
 using AcademyResidentInformationApi.V1.Infrastructure;
@@ -15,6 +16,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
     public class AcademyGatewayTests : DatabaseTests
     {
         private AcademyGateway _classUnderTest;
+        private readonly Cursor _defaultCursor = new Cursor { ClaimId = 0, HouseId = 0, MemberId = 0 };
 
         [SetUp]
         public new void Setup()
@@ -98,7 +100,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         [Test]
         public void GetAllClaimantsIfThereAreNoClaimantsReturnsAnEmptyList()
         {
-            _classUnderTest.GetAllClaimants(0, 20).Should().BeEmpty();
+            _classUnderTest.GetAllClaimants(_defaultCursor, 20).Should().BeEmpty();
         }
 
         [Test]
@@ -111,7 +113,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             var expectedDomain = personEntity.ToDomain();
             expectedDomain.CheckDigit = claim.CheckDigit;
 
-            var personFromList = _classUnderTest.GetAllClaimants(0, 20)
+            var personFromList = _classUnderTest.GetAllClaimants(_defaultCursor, 20)
                 .First(p => p.ClaimId == personEntity.ClaimId);
 
             personFromList.CheckDigit.Should().Be(claim.CheckDigit);
@@ -126,7 +128,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             var domainEntity = databaseEntity.ToDomain();
             domainEntity.ClaimantAddress = address.ToDomain();
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(0, 20, postcode: address.PostCode);
+            var listOfPersons = _classUnderTest.GetAllClaimants(_defaultCursor, 20, postcode: address.PostCode);
 
             listOfPersons
                 .First(p => p.ClaimId == databaseEntity.ClaimId)
@@ -145,7 +147,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             var newAddress = AddAddressToDatabase(newPersonRecord.ClaimId, newPersonRecord.HouseId);
 
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(0, 20);
+            var listOfPersons = _classUnderTest.GetAllClaimants(_defaultCursor, 20);
             var expectedDomain = newPersonRecord.ToDomain();
 
             listOfPersons.Should().BeEquivalentTo(expectedDomain);
@@ -168,7 +170,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             var domainEntity2 = databaseEntity2.ToDomain();
             domainEntity2.ClaimantAddress = address2.ToDomain();
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: 0, limit: 20, firstname: "ciasom");
+            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: _defaultCursor, limit: 20, firstname: "ciasom");
             listOfPersons.Count.Should().Be(2);
             listOfPersons.Should().ContainEquivalentOf(domainEntity);
             listOfPersons.Should().ContainEquivalentOf(domainEntity2);
@@ -200,7 +202,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             var domainEntity2 = databaseEntity2.ToDomain();
             domainEntity2.ClaimantAddress = address2.ToDomain();
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: 0, limit: 20, firstname: "iaso");
+            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: _defaultCursor, limit: 20, firstname: "iaso");
             listOfPersons.Count.Should().Be(2);
             listOfPersons.Should().ContainEquivalentOf(domainEntity);
             listOfPersons.Should().ContainEquivalentOf(domainEntity2);
@@ -224,7 +226,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             var domainEntity2 = databaseEntity2.ToDomain();
             domainEntity2.ClaimantAddress = address2.ToDomain();
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: 0, limit: 20, lastname: "tessellate");
+            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: _defaultCursor, limit: 20, lastname: "tessellate");
             listOfPersons.Count.Should().Be(2);
             listOfPersons.Should().ContainEquivalentOf(domainEntity);
             listOfPersons.Should().ContainEquivalentOf(domainEntity2);
@@ -255,7 +257,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             var domainEntity2 = databaseEntity2.ToDomain();
             domainEntity2.ClaimantAddress = address2.ToDomain();
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: 0, limit: 20, lastname: "sell");
+            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: _defaultCursor, limit: 20, lastname: "sell");
             listOfPersons.Count.Should().Be(2);
             listOfPersons.Should().ContainEquivalentOf(domainEntity);
             listOfPersons.Should().ContainEquivalentOf(domainEntity2);
@@ -270,7 +272,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             AcademyContext.Addresses.Add(address);
             AcademyContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: 0, limit: 20, firstname: "ciasom", lastname: "Tessellate");
+            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: _defaultCursor, limit: 20, firstname: "ciasom", lastname: "Tessellate");
             var firstPersonId = listOfPersons.First().ClaimId;
 
             listOfPersons.Count.Should().Be(1);
@@ -286,7 +288,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             AcademyContext.Addresses.Add(address);
             AcademyContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: 0, limit: 20, firstname: "ciaso", lastname: "essellat");
+            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: _defaultCursor, limit: 20, firstname: "ciaso", lastname: "essellat");
             var firstPersonId = listOfPersons.First().ClaimId;
 
             listOfPersons.Count.Should().Be(1);
@@ -307,7 +309,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             AcademyContext.Addresses.Add(address1);
             AcademyContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: 0, limit: 20, postcode: "E8 1DY");
+            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: _defaultCursor, limit: 20, postcode: "E8 1DY");
             listOfPersons.Count.Should().Be(1);
             listOfPersons
                 .First(p => p.ClaimId == databaseEntity.ClaimId)
@@ -333,7 +335,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             AcademyContext.Addresses.Add(address2);
             AcademyContext.SaveChanges();
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: 0, limit: 20, firstname: "ciasom", postcode: "E8 1DY").ToList();
+            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: _defaultCursor, limit: 20, firstname: "ciasom", postcode: "E8 1DY").ToList();
             var firstPersonId = listOfPersons.First().ClaimId;
 
             listOfPersons.Count.Should().Be(1);
@@ -350,7 +352,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             var databaseEntity = AddPersonRecordToDatabase();
             var address = AddAddressToDatabase(databaseEntity.ClaimId, databaseEntity.HouseId, postcode: postcode);
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: 0, limit: 20, postcode: "E8 1DY");
+            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: _defaultCursor, limit: 20, postcode: "E8 1DY");
             var firstPersonId = listOfPersons.First().ClaimId;
 
             listOfPersons.Count.Should().Be(1);
@@ -372,7 +374,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             var address = AddAddressToDatabase(databaseEntity.ClaimId, databaseEntity.HouseId, address: "1 My Street, Hackney, London");
             var address1 = AddAddressToDatabase(databaseEntity1.ClaimId, databaseEntity.HouseId, address: "5 Another Street, Lambeth, London");
 
-            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: 0, limit: 20, address: addressQuery).ToList();
+            var listOfPersons = _classUnderTest.GetAllClaimants(cursor: _defaultCursor, limit: 20, address: addressQuery).ToList();
             listOfPersons.Count.Should().Be(1);
             listOfPersons
                 .First(p => p.ClaimId == databaseEntity.ClaimId)
@@ -391,7 +393,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             }.OrderBy(p => p.ClaimId).ToList();
             manyPeople.ForEach(p => AddAddressToDatabase(p.ClaimId, p.HouseId));
 
-            var peopleReturned = _classUnderTest.GetAllClaimants(0, 2);
+            var peopleReturned = _classUnderTest.GetAllClaimants(_defaultCursor, 2);
             peopleReturned.Count.Should().Be(2);
         }
 
@@ -400,16 +402,20 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         {
             var manyPeople = new List<Person>
             {
-                AddPersonRecordToDatabase(),
-                AddPersonRecordToDatabase(),
-                AddPersonRecordToDatabase()
+                AddPersonRecordToDatabase(id: 23, houseId: 1, memberId: 1),
+                AddPersonRecordToDatabase(id: 23, houseId: 2, memberId: 2, withClaim: false),
+                AddPersonRecordToDatabase(id: 23, houseId: 3, memberId: 1, withClaim: false),
+                AddPersonRecordToDatabase(id: 23, houseId: 4, memberId: 4, withClaim: false),
+                AddPersonRecordToDatabase(id: 1000, houseId: 2, memberId: 4)
             }.OrderBy(p => p.ClaimId).ToList();
             manyPeople.ForEach(p => AddAddressToDatabase(p.ClaimId, p.HouseId));
 
-            var peopleReturned = _classUnderTest.GetAllClaimants(1, 2);
-            peopleReturned.Count.Should().Be(2);
-            peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(1).ClaimId);
+            var cursor = new Cursor { ClaimId = 23, HouseId = 2, MemberId = 2 };
+            var peopleReturned = _classUnderTest.GetAllClaimants(cursor, 20);
+            peopleReturned.Count.Should().Be(3);
             peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(2).ClaimId);
+            peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(3).ClaimId);
+            peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(4).ClaimId);
         }
 
         [Test]
@@ -417,16 +423,20 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         {
             var manyPeople = new List<Person>
             {
-                AddPersonRecordToDatabase(id: 3),
-                AddPersonRecordToDatabase(id: 1),
-                AddPersonRecordToDatabase(id: 7)
-            }.ToList();
+                AddPersonRecordToDatabase(id: 23, houseId: 2, memberId: 2),
+                AddPersonRecordToDatabase(id: 23, houseId: 3, memberId: 1, withClaim: false),
+                AddPersonRecordToDatabase(id: 23, houseId: 1, memberId: 1, withClaim: false),
+                AddPersonRecordToDatabase(id: 23, houseId: 4, memberId: 4, withClaim: false),
+                AddPersonRecordToDatabase(id: 1000, houseId: 2, memberId: 4)
+            }.OrderBy(p => p.ClaimId).ToList();
             manyPeople.ForEach(p => AddAddressToDatabase(p.ClaimId, p.HouseId));
 
-            var peopleReturned = _classUnderTest.GetAllClaimants(1, 2);
-            peopleReturned.Count.Should().Be(2);
-            peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(0).ClaimId);
-            peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(2).ClaimId);
+            var cursor = new Cursor { ClaimId = 23, HouseId = 2, MemberId = 2 };
+            var peopleReturned = _classUnderTest.GetAllClaimants(cursor, 20);
+            peopleReturned.Count.Should().Be(3);
+            peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(1).ClaimId);
+            peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(3).ClaimId);
+            peopleReturned.Should().Contain(ci => ci.ClaimId == manyPeople.ElementAt(4).ClaimId);
         }
         private Person AddPersonRecordToDatabase(string firstname = null, string lastname = null, int? id = null,
             bool withClaim = true, int? memberId = null, int? personRef = null, int? houseId = null)

--- a/AcademyResidentInformationApi.Tests/V1/UseCase/GetAllClaimantsUseCaseTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/UseCase/GetAllClaimantsUseCaseTests.cs
@@ -1,5 +1,6 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
-using AcademyResidentInformationApi.V1.Boundary.Responses;
 using AcademyResidentInformationApi.V1.Factories;
 using AcademyResidentInformationApi.V1.Gateways;
 using AcademyResidentInformationApi.V1.UseCase;
@@ -7,6 +8,8 @@ using AutoFixture;
 using FluentAssertions;
 using Moq;
 using AcademyResidentInformationApi.V1.Boundary.Requests;
+using AcademyResidentInformationApi.V1.Boundary.Responses;
+using AcademyResidentInformationApi.V1.Domain;
 using NUnit.Framework;
 using ClaimantInformation = AcademyResidentInformationApi.V1.Domain.ClaimantInformation;
 
@@ -29,20 +32,20 @@ namespace AcademyResidentInformationApi.Tests.V1.UseCase
         [Test]
         public void ReturnsClaimantInformationList()
         {
-            var stubbedClaimants = _fixture.CreateMany<ClaimantInformation>();
+            var stubbedClaimants = _fixture.CreateMany<ClaimantInformation>().ToList();
 
             _mockAcademyGateway.Setup(x =>
-                x.GetAllClaimants(0, 20, "ciasom", "tessellate", "E8 1DY", "1 Montage street"))
-                .Returns(stubbedClaimants.ToList());
+                x.GetAllClaimants(It.IsAny<Cursor>(), 20, "ciasom", "tessellate", "E8 1DY", "1 Montage street"))
+                .Returns(stubbedClaimants);
 
-            var cqp = new ClaimantQueryParam()
+            var cqp = new ClaimantQueryParam
             {
                 FirstName = "ciasom",
                 LastName = "tessellate",
                 Postcode = "E8 1DY",
                 Address = "1 Montage street"
             };
-            var response = _classUnderTest.Execute(cqp, 0, 20);
+            var response = _classUnderTest.Execute(cqp, null, 20);
 
             response.Should().NotBeNull();
             response.Claimants.Should().BeEquivalentTo(stubbedClaimants.ToResponse());
@@ -54,12 +57,10 @@ namespace AcademyResidentInformationApi.Tests.V1.UseCase
             var stubbedClaimants = _fixture.CreateMany<ClaimantInformation>(101);
 
             _mockAcademyGateway.Setup(x =>
-                x.GetAllClaimants(0, 100, null, null, null, null))
+                x.GetAllClaimants(It.IsAny<Cursor>(), 100, null, null, null, null))
                 .Returns(stubbedClaimants.ToList()).Verifiable();
 
-            var cqp = new ClaimantQueryParam();
-
-            var response = _classUnderTest.Execute(cqp, 0, 101);
+            _classUnderTest.Execute(new ClaimantQueryParam(), null, 101);
 
             _mockAcademyGateway.Verify();
         }
@@ -70,14 +71,63 @@ namespace AcademyResidentInformationApi.Tests.V1.UseCase
             var stubbedClaimants = _fixture.CreateMany<ClaimantInformation>(20);
 
             _mockAcademyGateway.Setup(x =>
-                x.GetAllClaimants(0, 10, null, null, null, null))
+                x.GetAllClaimants(It.IsAny<Cursor>(), 10, null, null, null, null))
                 .Returns(stubbedClaimants.ToList()).Verifiable();
 
-            var cqp = new ClaimantQueryParam();
-
-            var response = _classUnderTest.Execute(cqp, 0, 2);
+            _classUnderTest.Execute(new ClaimantQueryParam(), null, 2);
 
             _mockAcademyGateway.Verify();
         }
+
+        [Test]
+        public void ExecuteWillPassADefaultCursorIfOneIsNotGiven()
+        {
+            var defaultCursor = new Cursor { ClaimId = 0, HouseId = 0, MemberId = 0 };
+            _mockAcademyGateway.Setup(x => x.GetAllClaimants(CheckCursorIs(defaultCursor), 20, null, null, null, null))
+                .Returns(new List<ClaimantInformation>());
+            _classUnderTest.Execute(new ClaimantQueryParam(), null, 20);
+            _mockAcademyGateway.Verify();
+        }
+
+        [Test]
+        public void ExecuteWillDeconstructACursorPassedToIt()
+        {
+            var expectedCursor = new Cursor { ClaimId = 3400002, HouseId = 34, MemberId = 2 };
+            _mockAcademyGateway.Setup(x => x.GetAllClaimants(CheckCursorIs(expectedCursor), 20, null, null, null, null))
+                .Returns(new List<ClaimantInformation>());
+            _classUnderTest.Execute(new ClaimantQueryParam(), "3400002-34-2", 20);
+            _mockAcademyGateway.Verify();
+        }
+
+        [Test]
+        public void ExecuteWillConstructTheNextCursorAndReturnIt()
+        {
+            var lastReturnedClaimant = _fixture.Build<ClaimantInformation>()
+                .With(c => c.ClaimId, 3400002)
+                .With(c => c.HouseId, 34)
+                .With(c => c.MemberId, 2)
+                .Create();
+            var stubbedClaimants = _fixture.CreateMany<ClaimantInformation>(19).ToList();
+            stubbedClaimants.Add(lastReturnedClaimant);
+
+            _mockAcademyGateway.Setup(x => x.GetAllClaimants(It.IsAny<Cursor>(), 20, null, null, null, null))
+                .Returns(stubbedClaimants);
+            _classUnderTest.Execute(new ClaimantQueryParam(), null, 20).NextCursor.Should().Be("3400002-34-2");
+        }
+
+        [Test]
+        public void IfTheGivenCursorHasTheWrongFormatItThrows()
+        {
+            Func<ClaimantInformationList> testDelegate = () =>
+                _classUnderTest.Execute(new ClaimantQueryParam(), "222/78", 20);
+            testDelegate.Should().Throw<InvalidCursorException>("The cursor provided is in the wrong format, please use the cursor provided in the previous response or if this is the first request leave it blank");
+        }
+
+        private static Cursor CheckCursorIs(Cursor cursor)
+        {
+            return It.Is<Cursor>(c =>
+                c.ClaimId == cursor.ClaimId && c.HouseId == cursor.HouseId && c.MemberId == cursor.MemberId);
+        }
     }
 }
+

--- a/AcademyResidentInformationApi/V1/Boundary/Responses/ClaimantInformationList.cs
+++ b/AcademyResidentInformationApi/V1/Boundary/Responses/ClaimantInformationList.cs
@@ -5,5 +5,7 @@ namespace AcademyResidentInformationApi.V1.Boundary.Responses
     public class ClaimantInformationList
     {
         public List<ClaimantInformation> Claimants { get; set; }
+
+        public string NextCursor { get; set; }
     }
 }

--- a/AcademyResidentInformationApi/V1/Controllers/AcademyController.cs
+++ b/AcademyResidentInformationApi/V1/Controllers/AcademyController.cs
@@ -1,4 +1,3 @@
-using System;
 using AcademyResidentInformationApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using AcademyResidentInformationApi.V1.Boundary.Requests;
@@ -22,15 +21,19 @@ namespace AcademyResidentInformationApi.V1.Controllers
         }
 
         [HttpGet]
-        public IActionResult ListContacts([FromQuery] ClaimantQueryParam cqp, int? cursor = 0, int? limit = 20)
+        public IActionResult ListContacts([FromQuery] ClaimantQueryParam cqp, string cursor = null, int? limit = 20)
         {
             try
             {
-                return Ok(_getAllClaimantsUseCase.Execute(cqp, (int) cursor, (int) limit));
+                return Ok(_getAllClaimantsUseCase.Execute(cqp, cursor, (int) limit));
             }
             catch (InvalidQueryParameterException e)
             {
                 //return 400
+                return BadRequest(e.Message);
+            }
+            catch (InvalidCursorException e)
+            {
                 return BadRequest(e.Message);
             }
 

--- a/AcademyResidentInformationApi/V1/Domain/ClaimantInformation.cs
+++ b/AcademyResidentInformationApi/V1/Domain/ClaimantInformation.cs
@@ -13,6 +13,9 @@ namespace AcademyResidentInformationApi.V1.Domain
         public string NINumber { get; set; }
         public Address ClaimantAddress { get; set; }
         public string CheckDigit { get; set; }
+
+        public int MemberId { get; set; }
+        public int HouseId { get; set; }
     }
 
     public class Address

--- a/AcademyResidentInformationApi/V1/Domain/Cursor.cs
+++ b/AcademyResidentInformationApi/V1/Domain/Cursor.cs
@@ -1,0 +1,9 @@
+namespace AcademyResidentInformationApi.V1.Domain
+{
+    public class Cursor
+    {
+        public int ClaimId { get; set; }
+        public int MemberId { get; set; }
+        public int HouseId { get; set; }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Domain/InvalidCursorException.cs
+++ b/AcademyResidentInformationApi/V1/Domain/InvalidCursorException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace AcademyResidentInformationApi.V1.Domain
+{
+    public class InvalidCursorException : Exception
+    {
+        public InvalidCursorException(string message) : base(message)
+        { }
+
+        public InvalidCursorException()
+        { }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Factories/EntityFactory.cs
+++ b/AcademyResidentInformationApi/V1/Factories/EntityFactory.cs
@@ -21,7 +21,9 @@ namespace AcademyResidentInformationApi.V1.Factories
                 LastName = databaseEntity.LastName,
                 NINumber = databaseEntity.NINumber,
                 DateOfBirth = databaseEntity.DateOfBirth,
-                ClaimantAddress = databaseEntity.Address?.ToDomain()
+                ClaimantAddress = databaseEntity.Address?.ToDomain(),
+                HouseId = databaseEntity.HouseId.Value,
+                MemberId = databaseEntity.MemberId.Value
             };
         }
 

--- a/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
+using AcademyResidentInformationApi.V1.Domain;
 using AcademyResidentInformationApi.V1.Factories;
 using AcademyResidentInformationApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
+using Address = AcademyResidentInformationApi.V1.Infrastructure.Address;
 using ClaimantInformation = AcademyResidentInformationApi.V1.Domain.ClaimantInformation;
 
 namespace AcademyResidentInformationApi.V1.Gateways
@@ -16,7 +18,7 @@ namespace AcademyResidentInformationApi.V1.Gateways
             _academyContext = academyContext;
         }
 
-        public List<ClaimantInformation> GetAllClaimants(int cursor, int limit, string firstname = null,
+        public List<ClaimantInformation> GetAllClaimants(Cursor cursor, int limit, string firstname = null,
             string lastname = null, string postcode = null, string address = null)
         {
             var firstNameSearchPattern = GetSearchPattern(firstname);
@@ -32,6 +34,7 @@ namespace AcademyResidentInformationApi.V1.Gateways
                 where string.IsNullOrEmpty(postcode) || EF.Functions.ILike(a.PostCode.Replace(" ", ""), postcodeSearchPattern)
                 where string.IsNullOrEmpty(firstname) || EF.Functions.ILike(person.FirstName, firstNameSearchPattern)
                 where string.IsNullOrEmpty(lastname) || EF.Functions.ILike(person.LastName, lastNameSearchPattern)
+                where person.ClaimId > cursor.ClaimId || person.HouseId > cursor.HouseId || person.MemberId > cursor.MemberId
                 orderby person.ClaimId, person.HouseId, person.MemberId
                 select new Person
                 {
@@ -48,7 +51,7 @@ namespace AcademyResidentInformationApi.V1.Gateways
                     DateOfBirth = person.DateOfBirth,
                     NINumber = person.NINumber
                 }
-                ).Skip(cursor).Take(limit).ToList().ToDomain();
+                ).Take(limit).ToList().ToDomain();
         }
         private static string GetSearchPattern(string str)
         {

--- a/AcademyResidentInformationApi/V1/Gateways/IAcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/IAcademyGateway.cs
@@ -7,7 +7,7 @@ namespace AcademyResidentInformationApi.V1.Gateways
 {
     public interface IAcademyGateway
     {
-        List<ClaimantInformation> GetAllClaimants(int cursor, int limit, string firstname = null,
+        List<ClaimantInformation> GetAllClaimants(Cursor cursor, int limit, string firstname = null,
             string lastname = null, string postcode = null, string address = null);
         ClaimantInformation GetClaimantById(int claimId, int personRef);
     }

--- a/AcademyResidentInformationApi/V1/UseCase/GetAllClaimantsUseCase.cs
+++ b/AcademyResidentInformationApi/V1/UseCase/GetAllClaimantsUseCase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using AcademyResidentInformationApi.V1.Boundary.Responses;
 using AcademyResidentInformationApi.V1.Factories;
 using AcademyResidentInformationApi.V1.Gateways;
@@ -18,7 +19,7 @@ namespace AcademyResidentInformationApi.V1.UseCase
             _validatePostcode = new ValidatePostcode();
         }
 
-        public ClaimantInformationList Execute(ClaimantQueryParam cqp, int cursor, int limit)
+        public ClaimantInformationList Execute(ClaimantQueryParam cqp, string cursor, int limit)
         {
             //Check if the query parameter includes a value for postcode
             if (!string.IsNullOrWhiteSpace(cqp.Postcode))
@@ -27,13 +28,37 @@ namespace AcademyResidentInformationApi.V1.UseCase
             limit = limit < 10 ? 10 : limit;
             limit = limit > 100 ? 100 : limit;
 
-            var claimants = _academyGateway.GetAllClaimants(cursor, limit, cqp.FirstName, cqp.LastName, cqp.Postcode, cqp.Address);
+
+            var claimants = _academyGateway.GetAllClaimants(DeconstructCursor(cursor), limit, cqp.FirstName, cqp.LastName, cqp.Postcode, cqp.Address);
+
+            var lastClaimant = claimants.LastOrDefault();
+            var nextCursor = claimants.Count == limit ? $"{lastClaimant.ClaimId}-{lastClaimant.HouseId}-{lastClaimant.MemberId}" : "";
             return new ClaimantInformationList
             {
-                Claimants = claimants.ToResponse()
+                Claimants = claimants.ToResponse(),
+                NextCursor = nextCursor
             };
         }
 
+        private static Cursor DeconstructCursor(string cursor)
+        {
+            if (cursor == null) return new Cursor { ClaimId = 0, HouseId = 0, MemberId = 0 };
+            try
+            {
+                var values = cursor.Split('-');
+
+                return new Cursor
+                {
+                    ClaimId = Convert.ToInt32(values.ElementAt(0)),
+                    HouseId = Convert.ToInt32(values.ElementAt(1)),
+                    MemberId = Convert.ToInt32(values.ElementAt(2)),
+                };
+            }
+            catch (Exception)
+            {
+                throw new InvalidCursorException("The cursor provided is in the wrong format, please use the cursor provided in the previous response or if this is the first request leave it blank");
+            }
+        }
 
         private void CheckPostCodeValid(string postcode)
         {

--- a/AcademyResidentInformationApi/V1/UseCase/Interfaces/IGetAllClaimantsUseCase.cs
+++ b/AcademyResidentInformationApi/V1/UseCase/Interfaces/IGetAllClaimantsUseCase.cs
@@ -6,7 +6,7 @@ namespace AcademyResidentInformationApi.V1.UseCase.Interfaces
 {
     public interface IGetAllClaimantsUseCase
     {
-        ClaimantInformationList Execute(ClaimantQueryParam cqp, int cursor, int limit);
+        ClaimantInformationList Execute(ClaimantQueryParam cqp, string cursor, int limit);
     }
 
 }


### PR DESCRIPTION
Updated [swagger](https://app.swaggerhub.com/apis/Hackney/academy-resident_information_api/1.0) to include the `nextCursor` response field.