### PR TITLE
Add council tax payer view endpoint

### DIFF
--- a/AcademyResidentInformationApi.Tests/DatabaseTests.cs
+++ b/AcademyResidentInformationApi.Tests/DatabaseTests.cs
@@ -1,4 +1,3 @@
-using System;
 using AcademyResidentInformationApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;

--- a/AcademyResidentInformationApi.Tests/V1/Controllers/ClaimantsControllerTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Controllers/ClaimantsControllerTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using AcademyResidentInformationApi.V1.Boundary.Responses;
 using AcademyResidentInformationApi.V1.Controllers;
 using AcademyResidentInformationApi.V1.UseCase.Interfaces;
@@ -14,9 +13,9 @@ using ClaimantInformation = AcademyResidentInformationApi.V1.Boundary.Responses.
 namespace AcademyResidentInformationApi.Tests.V1.Controllers
 {
     [TestFixture]
-    public class AcademyControllerTests
+    public class ClaimantsControllerTests
     {
-        private AcademyController _classUnderTest;
+        private ClaimantsController _classUnderTest;
         private Mock<IGetAllClaimantsUseCase> _mockGetAllClaimantsUseCase;
         private Mock<IGetClaimantByIdUseCase> _mockGetClaimantByIdUseCase;
 
@@ -25,7 +24,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Controllers
         {
             _mockGetAllClaimantsUseCase = new Mock<IGetAllClaimantsUseCase>();
             _mockGetClaimantByIdUseCase = new Mock<IGetClaimantByIdUseCase>();
-            _classUnderTest = new AcademyController(_mockGetAllClaimantsUseCase.Object, _mockGetClaimantByIdUseCase.Object);
+            _classUnderTest = new ClaimantsController(_mockGetAllClaimantsUseCase.Object, _mockGetClaimantByIdUseCase.Object);
         }
 
         [Test]

--- a/AcademyResidentInformationApi.Tests/V1/Controllers/TaxPayersControllerTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Controllers/TaxPayersControllerTests.cs
@@ -1,0 +1,48 @@
+using AcademyResidentInformationApi.V1.Boundary.Responses;
+using AcademyResidentInformationApi.V1.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using AcademyResidentInformationApi.V1.Domain;
+using AcademyResidentInformationApi.V1.UseCase;
+using AutoFixture;
+using NUnit.Framework;
+
+namespace AcademyResidentInformationApi.Tests.V1.Controllers
+{
+    [TestFixture]
+    public class TaxPayersControllerTests
+    {
+        private TaxPayersController _classUnderTest;
+        private Mock<IGetTaxPayerByIdUseCase> _mockGetTaxPayerByIdUseCase;
+        private readonly IFixture _fixture = new Fixture();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockGetTaxPayerByIdUseCase = new Mock<IGetTaxPayerByIdUseCase>();
+            _classUnderTest = new TaxPayersController(_mockGetTaxPayerByIdUseCase.Object);
+        }
+
+        [Test]
+        public void ViewTaxPayerReturns200WhenSuccessful()
+        {
+            var taxPayer = _fixture.Create<TaxPayerInformationResponse>();
+
+            _mockGetTaxPayerByIdUseCase.Setup(x => x.Execute(123)).Returns(taxPayer);
+            var response = _classUnderTest.ViewRecord(123) as OkObjectResult;
+
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(taxPayer);
+        }
+
+        [Test]
+        public void ViewReturnsA404IfNotFoundExceptionThrown()
+        {
+            _mockGetTaxPayerByIdUseCase.Setup(x => x.Execute(It.IsAny<int>())).Throws<TaxPayerNotFoundException>();
+            var response = _classUnderTest.ViewRecord(123) as NotFoundResult;
+            response.StatusCode.Should().Be(404);
+        }
+    }
+}

--- a/AcademyResidentInformationApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/AcademyResidentInformationApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using AcademyResidentInformationApi.Tests.V1.Helper;
 using AcademyResidentInformationApi.V1.Boundary.Responses;
 using AcademyResidentInformationApi.V1.Infrastructure;
@@ -7,9 +8,9 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
 {
     public static class E2ETestHelpers
     {
-        public static ClaimantInformation AddPersonWithRelatesEntitiesToDb(AcademyContext context, int? claimId = null, int? personRef = null, string firstname = null, string lastname = null, string postcode = null, string addressLines = null)
+        public static ClaimantInformation AddClaimantWithRelatesEntitiesToDb(AcademyContext context, int? claimId = null, int? personRef = null, string firstname = null, string lastname = null, string postcode = null, string addressLines = null)
         {
-            var person = TestHelper.CreateDatabasePersonEntity();
+            var person = TestHelper.CreateDatabaseClaimantEntity();
             person.ClaimId = claimId ?? person.ClaimId;
             person.PersonRef = personRef ?? person.PersonRef;
 
@@ -48,6 +49,54 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
                     Postcode = address.PostCode
                 }
 
+            };
+        }
+
+        public static TaxPayerInformationResponse AddTaxPayerWithRelatesEntitiesToDb(AcademyContext context,
+            int? accountRef = null, string firstname = null, string lastname = null,
+            string postcode = null, string addressLines = null)
+        {
+            var person = TestHelper.CreateDatabaseTaxPayerEntity(accountRef, firstname, lastname);
+            person.AccountRef = accountRef ?? person.AccountRef;
+
+            person.FirstName = firstname ?? person.FirstName;
+            person.LastName = lastname ?? person.LastName;
+
+            context.TaxPayers.Add(person);
+            context.SaveChanges();
+
+            var occupation = TestHelper.CreateDatabaseOccupationEntityForCouncilProperty(person.AccountRef);
+            context.Occupations.Add(occupation);
+            context.SaveChanges();
+
+            var property = TestHelper.CreateDatabasePropertyForTaxPayer(occupation.PropertyRef);
+            context.CouncilProperties.Add(property);
+            context.SaveChanges();
+
+            var email = TestHelper.CreateDatabaseEmailAddressForTaxPayer(person.AccountRef);
+            context.Emails.Add(email);
+            context.SaveChanges();
+
+            var phoneNumber = TestHelper.CreateDatabasePhoneNumbersForTaxPayer(person.AccountRef);
+            context.PhoneNumbers.Add(phoneNumber);
+            context.SaveChanges();
+
+            return new TaxPayerInformationResponse()
+            {
+                AccountRef = person.AccountRef,
+                FirstName = person.FirstName,
+                LastName = person.LastName,
+                EmailList = new List<string>{ email.EmailAddress },
+                PhoneNumberList = new List<string>{ phoneNumber.Number1, phoneNumber.Number2, phoneNumber.Number3, phoneNumber.Number4 },
+                TaxPayerAddress = new Address
+                {
+                    AddressLine1 = property.AddressLine1,
+                    AddressLine2 = property.AddressLine2,
+                    AddressLine3 = property.AddressLine3,
+                    AddressLine4 = property.AddressLine4,
+                    Postcode = property.PostCode
+                },
+                UPRN = property.Uprn
             };
         }
     }

--- a/AcademyResidentInformationApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/AcademyResidentInformationApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -86,8 +86,8 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
                 AccountRef = person.AccountRef,
                 FirstName = person.FirstName,
                 LastName = person.LastName,
-                EmailList = new List<string>{ email.EmailAddress },
-                PhoneNumberList = new List<string>{ phoneNumber.Number1, phoneNumber.Number2, phoneNumber.Number3, phoneNumber.Number4 },
+                EmailList = new List<string> { email.EmailAddress },
+                PhoneNumberList = new List<string> { phoneNumber.Number1, phoneNumber.Number2, phoneNumber.Number3, phoneNumber.Number4 },
                 TaxPayerAddress = new Address
                 {
                     AddressLine1 = property.AddressLine1,

--- a/AcademyResidentInformationApi.Tests/V1/E2ETests/GetClaimantInformationById.cs
+++ b/AcademyResidentInformationApi.Tests/V1/E2ETests/GetClaimantInformationById.cs
@@ -24,7 +24,7 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
         {
             var claimId = _fixture.Create<int>();
             var personRef = _fixture.Create<int>();
-            var expectedResponse = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, claimId: claimId, personRef: personRef);
+            var expectedResponse = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, claimId: claimId, personRef: personRef);
 
             var requestUri = new Uri($"api/v1/claimants/claim/{claimId}/person/{personRef}", UriKind.Relative);
             var response = Client.GetAsync(requestUri);

--- a/AcademyResidentInformationApi.Tests/V1/E2ETests/GetTaxPayerById.cs
+++ b/AcademyResidentInformationApi.Tests/V1/E2ETests/GetTaxPayerById.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+using AcademyResidentInformationApi.V1.Boundary.Responses;
+using AutoFixture;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace AcademyResidentInformationApi.Tests.V1.E2ETests
+{
+    public class GetTaxPayerById : IntegrationTests<Startup>
+    {
+        private readonly IFixture _fixture = new Fixture();
+
+        [Test]
+        public async Task GetTaxPayerByIdReturnsTheCorrectInformation()
+        {
+            var accountRef = _fixture.Create<int>();
+            var expectedResponse = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, accountRef);
+
+            var requestUri = new Uri($"api/v1/tax-payers/{accountRef}", UriKind.Relative);
+            var response = Client.GetAsync(requestUri);
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync();
+            var convertedResponse = JsonConvert.DeserializeObject<TaxPayerInformationResponse>(stringContent);
+
+            convertedResponse.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
+        public void GetTaxPayerByIdReturns404NotFound()
+        {
+            var requestUri = new Uri($"api/v1/tax-payers/94837491", UriKind.Relative);
+            var response = Client.GetAsync(requestUri);
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(404);
+        }
+    }
+}

--- a/AcademyResidentInformationApi.Tests/V1/E2ETests/ListClaimantsReturnsAListOfAllClaimants.cs
+++ b/AcademyResidentInformationApi.Tests/V1/E2ETests/ListClaimantsReturnsAListOfAllClaimants.cs
@@ -23,9 +23,9 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
         [Test]
         public async Task IfNoQueryParametersListClaimantsReturnsAllClaimantRecordInAcademy()
         {
-            var expectedClaimantResponseOne = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext);
-            var expectedClaimantResponseTwo = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext);
-            var expectedClaimantResponseThree = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext);
+            var expectedClaimantResponseOne = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext);
+            var expectedClaimantResponseTwo = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext);
+            var expectedClaimantResponseThree = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext);
 
             var listUri = new Uri("/api/v1/claimants", UriKind.Relative);
 
@@ -44,9 +44,9 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
         [Test]
         public async Task FirstNameLastNameQueryParametersReturnsMatchingClaimantRecordsFromAcademy()
         {
-            var expectedClaimantResponseOne = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "tessellate");
-            var expectedClaimantResponseTwo = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "shape");
-            var expectedClaimantResponseThree = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext);
+            var expectedClaimantResponseOne = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "tessellate");
+            var expectedClaimantResponseTwo = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "shape");
+            var expectedClaimantResponseThree = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext);
 
             var queryUri = new Uri("api/v1/claimants?first_name=ciasom&last_name=tessellate", UriKind.Relative);
 
@@ -66,9 +66,9 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
         [Test]
         public async Task FirstNameLastNameQueryParametersWildcardSearchReturnsMatchingClaimantRecordsFromAcademy()
         {
-            var expectedClaimantResponseOne = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "tessellate");
-            var expectedClaimantResponseTwo = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "shape");
-            var expectedClaimantResponseThree = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext);
+            var expectedClaimantResponseOne = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "tessellate");
+            var expectedClaimantResponseTwo = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "shape");
+            var expectedClaimantResponseThree = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext);
 
             var queryUri = new Uri("api/v1/claimants?first_name=iasom&last_name=essellat", UriKind.Relative);
 
@@ -88,11 +88,11 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
         [Test]
         public async Task PostcodeAndAddressQueryParametersReturnsMatchingClaimantsRecordsFromAcademy()
         {
-            var matchingClaimantOne = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR", addressLines: "1 Seasame street, Hackney, LDN");
-            var matchingClaimantTwo = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR", addressLines: "1 Seasame street");
-            var nonMatchingClaimant1 = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, postcode: "E4 1RR");
-            var nonMatchingClaimant2 = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, addressLines: "1 Seasame street, Hackney, LDN", postcode: "E4 1RR");
-            var nonMatchingClaimant3 = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext);
+            var matchingClaimantOne = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR", addressLines: "1 Seasame street, Hackney, LDN");
+            var matchingClaimantTwo = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR", addressLines: "1 Seasame street");
+            var nonMatchingClaimant1 = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, postcode: "E4 1RR");
+            var nonMatchingClaimant2 = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, addressLines: "1 Seasame street, Hackney, LDN", postcode: "E4 1RR");
+            var nonMatchingClaimant3 = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext);
 
             var queryUri = new Uri("api/v1/claimants?postcode=e91rr&address=1 Seasame street", UriKind.Relative);
 
@@ -112,12 +112,12 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
         [Test]
         public async Task UsingAllQueryParametersReturnsMatchingClaimantsRecordsFromAcademy()
         {
-            var matchingClaimantOne = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR",
+            var matchingClaimantOne = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR",
                 addressLines: "1 Seasame street, Hackney, LDN", firstname: "ciasom", lastname: "shape");
-            var nonmatchingClaimantTwo = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, postcode: "E4 1RR", addressLines: "1 Seasame street", lastname: "shap");
-            var nonMatchingClaimant1 = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, postcode: "E4 1RR", firstname: "ciasom");
-            var nonMatchingClaimant2 = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext, addressLines: "1 Seasame street, Hackney, LDN", postcode: "E4 1RR");
-            var nonMatchingClaimant3 = E2ETestHelpers.AddPersonWithRelatesEntitiesToDb(AcademyContext);
+            var nonmatchingClaimantTwo = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, postcode: "E4 1RR", addressLines: "1 Seasame street", lastname: "shap");
+            var nonMatchingClaimant1 = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, postcode: "E4 1RR", firstname: "ciasom");
+            var nonMatchingClaimant2 = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, addressLines: "1 Seasame street, Hackney, LDN", postcode: "E4 1RR");
+            var nonMatchingClaimant3 = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext);
 
 
             var queryUri = new Uri("api/v1/claimants?postcode=e91rr&address=1 Seasame street&first_name=ciasom&last_name=shape", UriKind.Relative);

--- a/AcademyResidentInformationApi.Tests/V1/Factories/EntityFactoryTest.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Factories/EntityFactoryTest.cs
@@ -12,7 +12,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Factories
         [Test]
         public void ItMapsAPersonDatabaseRecordIntoClaimantInformationDomainObject()
         {
-            var personRecord = TestHelper.CreateDatabasePersonEntity();
+            var personRecord = TestHelper.CreateDatabaseClaimantEntity();
             var domain = personRecord.ToDomain();
             domain.Should().BeEquivalentTo(new ClaimantInformation
             {
@@ -31,7 +31,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Factories
         [Test]
         public void ItMapsTheAddressOntoTheClaimantInformationDomainObject()
         {
-            var personRecord = TestHelper.CreateDatabasePersonEntity();
+            var personRecord = TestHelper.CreateDatabaseClaimantEntity();
             var address = personRecord.Address =
                 TestHelper.CreateDatabaseAddressForPersonId(personRecord.ClaimId, personRecord.HouseId);
             var domain = personRecord.ToDomain();

--- a/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyCouncilTaxGatewayTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyCouncilTaxGatewayTests.cs
@@ -1,8 +1,10 @@
 using AcademyResidentInformationApi.Tests.V1.Helper;
+using AcademyResidentInformationApi.V1.Domain;
 using AcademyResidentInformationApi.V1.Gateways;
 using AcademyResidentInformationApi.V1.Infrastructure;
 using FluentAssertions;
 using NUnit.Framework;
+using Address = AcademyResidentInformationApi.V1.Domain.Address;
 
 namespace AcademyResidentInformationApi.Tests.V1.Gateways
 {
@@ -35,6 +37,8 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         public void GetCouncilTaxPayerInformationByAccountRefReturnsPersonalDetailsFromTheCTAccountTable()
         {
             var databaseEntity = AddTaxPayerDatabaseRecord(123456);
+            AddPropertyInformationForTaxPayer(databaseEntity.AccountRef);
+
             var response = _classUnderTest.GetTaxPayerById(databaseEntity.AccountRef);
 
             response.Should().NotBeNull();
@@ -43,12 +47,47 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             response.LastName.Should().Be(databaseEntity.LastName);
         }
 
+        [Test]
+        public void GetCouncilTaxPayerInformationByAccountRefReturnsDetailsFromTheCTPropertyTable()
+        {
+            var databaseEntity = AddTaxPayerDatabaseRecord(123456);
+            var propertyEntity = AddPropertyInformationForTaxPayer(databaseEntity.AccountRef);
+
+            var expectedTaxPayerAddress = new Address
+            {
+                AddressLine1 = propertyEntity.AddressLine1,
+                AddressLine2 = propertyEntity.AddressLine2,
+                AddressLine3 = propertyEntity.AddressLine3,
+                AddressLine4 = propertyEntity.AddressLine4,
+                PostCode = propertyEntity.PostCode
+            };
+
+            var response = _classUnderTest.GetTaxPayerById(databaseEntity.AccountRef);
+
+            response.Should().NotBeNull();
+            response.AccountRef.Should().Be(123456);
+            response.Uprn.Should().Be(propertyEntity.Uprn);
+            response.TaxPayerAddress.Should().BeEquivalentTo(expectedTaxPayerAddress);
+        }
+
         private TaxPayer AddTaxPayerDatabaseRecord(int? accountRef, string firstname = null, string lastname = null)
         {
             var databaseEntity = TestHelper.CreateDatabaseTaxPayerEntity(accountRef, firstname, lastname);
             AcademyContext.TaxPayers.Add(databaseEntity);
             AcademyContext.SaveChanges();
             return databaseEntity;
+        }
+
+        private CouncilProperty AddPropertyInformationForTaxPayer(int accountRef)
+        {
+            var occupationDetails = TestHelper.CreateDatabaseOccupationEntityForCouncilProperty(accountRef);
+            AcademyContext.Occupations.Add(occupationDetails);
+            AcademyContext.SaveChanges();
+
+            var propertyEntity = TestHelper.CreateDatabasePropertyForTaxPayer(occupationDetails.PropertyRef);
+            AcademyContext.CouncilProperties.Add(propertyEntity);
+            AcademyContext.SaveChanges();
+            return propertyEntity;
         }
     }
 }

--- a/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyCouncilTaxGatewayTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyCouncilTaxGatewayTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using AcademyResidentInformationApi.Tests.V1.Helper;
 using AcademyResidentInformationApi.V1.Domain;
 using AcademyResidentInformationApi.V1.Gateways;
@@ -70,6 +71,25 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             response.TaxPayerAddress.Should().BeEquivalentTo(expectedTaxPayerAddress);
         }
 
+        [Test]
+        public void GetCouncilTaxPayerInformationByAccountRefReturnsDetailsWithContactInformation()
+        {
+            const string testEmail = "test@email.com";
+
+            var testPhone = new List<string> { "00000000000", "122223333331" };
+
+            var databaseEntity = AddTaxPayerDatabaseRecord(123456);
+            AddPropertyInformationForTaxPayer(databaseEntity.AccountRef);
+            AddContactInformationForTaxPayer(databaseEntity.AccountRef, testEmail, testPhone);
+
+            var response = _classUnderTest.GetTaxPayerById(databaseEntity.AccountRef);
+
+            response.Should().NotBeNull();
+            response.AccountRef.Should().Be(123456);
+            response.EmailList.Should().BeEquivalentTo(new List<string> { testEmail });
+            response.PhoneNumberList.Should().BeEquivalentTo(testPhone);
+        }
+
         private TaxPayer AddTaxPayerDatabaseRecord(int? accountRef, string firstname = null, string lastname = null)
         {
             var databaseEntity = TestHelper.CreateDatabaseTaxPayerEntity(accountRef, firstname, lastname);
@@ -88,6 +108,17 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
             AcademyContext.CouncilProperties.Add(propertyEntity);
             AcademyContext.SaveChanges();
             return propertyEntity;
+        }
+
+        private void AddContactInformationForTaxPayer(int accountRef, string email, List<string> phoneNumbers)
+        {
+            var emailDetails = TestHelper.CreateDatabaseEmailAddressForTaxPayer(accountRef, email);
+            AcademyContext.Emails.Add(emailDetails);
+            AcademyContext.SaveChanges();
+
+            var phoneDetails = TestHelper.CreateDatabasePhoneNumbersForTaxPayer(accountRef, phoneNumbers);
+            AcademyContext.PhoneNumbers.Add(phoneDetails);
+            AcademyContext.SaveChanges();
         }
     }
 }

--- a/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyCouncilTaxGatewayTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyCouncilTaxGatewayTests.cs
@@ -1,0 +1,54 @@
+using AcademyResidentInformationApi.Tests.V1.Helper;
+using AcademyResidentInformationApi.V1.Gateways;
+using AcademyResidentInformationApi.V1.Infrastructure;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace AcademyResidentInformationApi.Tests.V1.Gateways
+{
+    [TestFixture]
+    public class AcademyCouncilTaxGatewayTests : DatabaseTests
+    {
+        private AcademyGateway _classUnderTest;
+
+
+        [SetUp]
+        public new void Setup()
+        {
+            _classUnderTest = new AcademyGateway(AcademyContext);
+        }
+
+        [Test]
+        public void GatewayImplementsBoundaryInterface()
+        {
+            Assert.NotNull(_classUnderTest is IAcademyGateway);
+        }
+
+        [Test]
+        public void GetCouncilTaxPayerInformationByAccountRefWhenThereAreNoMatchingRecordsReturnsNull()
+        {
+            var response = _classUnderTest.GetTaxPayerById(123456);
+            response.Should().BeNull();
+        }
+
+        [Test]
+        public void GetCouncilTaxPayerInformationByAccountRefReturnsPersonalDetailsFromTheCTAccountTable()
+        {
+            var databaseEntity = AddTaxPayerDatabaseRecord(123456);
+            var response = _classUnderTest.GetTaxPayerById(databaseEntity.AccountRef);
+
+            response.Should().NotBeNull();
+            response.AccountRef.Should().Be(123456);
+            response.FirstName.Should().Be(databaseEntity.FirstName);
+            response.LastName.Should().Be(databaseEntity.LastName);
+        }
+
+        private TaxPayer AddTaxPayerDatabaseRecord(int? accountRef, string firstname = null, string lastname = null)
+        {
+            var databaseEntity = TestHelper.CreateDatabaseTaxPayerEntity(accountRef, firstname, lastname);
+            AcademyContext.TaxPayers.Add(databaseEntity);
+            AcademyContext.SaveChanges();
+            return databaseEntity;
+        }
+    }
+}

--- a/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyCouncilTaxGatewayTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyCouncilTaxGatewayTests.cs
@@ -75,7 +75,6 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         public void GetCouncilTaxPayerInformationByAccountRefReturnsDetailsWithContactInformation()
         {
             const string testEmail = "test@email.com";
-
             var testPhone = new List<string> { "00000000000", "122223333331" };
 
             var databaseEntity = AddTaxPayerDatabaseRecord(123456);

--- a/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyGatewayTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyGatewayTests.cs
@@ -441,7 +441,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         private Person AddPersonRecordToDatabase(string firstname = null, string lastname = null, int? id = null,
             bool withClaim = true, int? memberId = null, int? personRef = null, int? houseId = null)
         {
-            var databaseEntity = TestHelper.CreateDatabasePersonEntity(firstname, lastname, id, memberId, personRef, houseId);
+            var databaseEntity = TestHelper.CreateDatabaseClaimantEntity(firstname, lastname, id, memberId, personRef, houseId);
             AcademyContext.Persons.Add(databaseEntity);
             AcademyContext.SaveChanges();
             if (withClaim)

--- a/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -1,9 +1,7 @@
 using System;
-using AcademyResidentInformationApi.V1.Boundary.Responses;
 using AcademyResidentInformationApi.V1.Infrastructure;
 using AutoFixture;
 using Address = AcademyResidentInformationApi.V1.Infrastructure.Address;
-using ClaimantInformation = AcademyResidentInformationApi.V1.Domain.ClaimantInformation;
 
 namespace AcademyResidentInformationApi.Tests.V1.Helper
 {
@@ -55,6 +53,17 @@ namespace AcademyResidentInformationApi.Tests.V1.Helper
                 CheckDigit = fixture.Create<char>().ToString()
             };
             return claim;
+        }
+
+        public static TaxPayer CreateDatabaseTaxPayerEntity(int? accountRef, string firstname = null, string lastname = null)
+        {
+            var faker = new Fixture();
+            var tp = faker.Build<TaxPayer>()
+                .Create();
+            tp.FirstName = firstname ?? tp.FirstName;
+            tp.LastName = lastname ?? tp.LastName;
+            tp.AccountRef = accountRef ?? tp.AccountRef;
+            return tp;
         }
     }
 }

--- a/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -9,7 +9,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Helper
 {
     public static class TestHelper
     {
-        public static Person CreateDatabasePersonEntity(string firstname = null, string lastname = null, int? id = null,
+        public static Person CreateDatabaseClaimantEntity(string firstname = null, string lastname = null, int? id = null,
             int? memberId = null, int? personRef = null, int? houseId = null)
         {
             var faker = new Fixture();

--- a/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using AcademyResidentInformationApi.V1.Infrastructure;
 using AutoFixture;
 using Address = AcademyResidentInformationApi.V1.Infrastructure.Address;
@@ -82,6 +84,35 @@ namespace AcademyResidentInformationApi.Tests.V1.Helper
                 .With(o => o.AccountRef, accountRef)
                 .Create();
             return cto;
+        }
+
+        public static Email CreateDatabaseEmailAddressForTaxPayer(int accountRef, string email = null)
+        {
+            var faker = new Fixture();
+            var fakeEmail = faker.Build<Email>()
+                .With(email => email.ReferenceId, accountRef)
+                .Create();
+
+            fakeEmail.EmailAddress = email ?? fakeEmail.EmailAddress;
+
+            return fakeEmail;
+        }
+
+        public static PhoneNumber CreateDatabasePhoneNumbersForTaxPayer(int accountRef, List<string> phoneNumbers = null)
+        {
+            var faker = new Fixture();
+            var fakePhone = faker.Build<PhoneNumber>()
+                .With(fp => fp.Reference, accountRef.ToString())
+                .Create();
+
+            if (phoneNumbers == null) return fakePhone;
+
+            fakePhone.Number1 = phoneNumbers.ElementAtOrDefault(0);
+            fakePhone.Number2 = phoneNumbers.ElementAtOrDefault(1);
+            fakePhone.Number3 = phoneNumbers.ElementAtOrDefault(2);
+            fakePhone.Number4 = phoneNumbers.ElementAtOrDefault(3);
+
+            return fakePhone;
         }
     }
 }

--- a/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -65,5 +65,23 @@ namespace AcademyResidentInformationApi.Tests.V1.Helper
             tp.AccountRef = accountRef ?? tp.AccountRef;
             return tp;
         }
+
+        public static CouncilProperty CreateDatabasePropertyForTaxPayer(string propertyRef)
+        {
+            var faker = new Fixture();
+            var cp = faker.Build<CouncilProperty>()
+                .With(p => p.PropertyRef, propertyRef)
+                .Create();
+            return cp;
+        }
+
+        public static Occupation CreateDatabaseOccupationEntityForCouncilProperty(int accountRef)
+        {
+            var faker = new Fixture();
+            var cto = faker.Build<Occupation>()
+                .With(o => o.AccountRef, accountRef)
+                .Create();
+            return cto;
+        }
     }
 }

--- a/AcademyResidentInformationApi.Tests/V1/Infrastructure/AcademyContextTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Infrastructure/AcademyContextTests.cs
@@ -10,7 +10,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Infrastructure
         [Test]
         public void CanGetADatabaseEntity()
         {
-            var databaseEntity = TestHelper.CreateDatabasePersonEntity();
+            var databaseEntity = TestHelper.CreateDatabaseClaimantEntity();
 
             AcademyContext.Add(databaseEntity);
             AcademyContext.SaveChanges();

--- a/AcademyResidentInformationApi.Tests/V1/UseCase/GetTaxPayerByIdUseCaseTest.cs
+++ b/AcademyResidentInformationApi.Tests/V1/UseCase/GetTaxPayerByIdUseCaseTest.cs
@@ -1,0 +1,56 @@
+using System;
+using AcademyResidentInformationApi.V1.Boundary.Responses;
+using AcademyResidentInformationApi.V1.Domain;
+using AcademyResidentInformationApi.V1.Factories;
+using AcademyResidentInformationApi.V1.Gateways;
+using AcademyResidentInformationApi.V1.UseCase;
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace AcademyResidentInformationApi.Tests.V1.UseCase
+{
+    public class GetTaxPayerByIdUseCaseTest
+    {
+        private Mock<IAcademyGateway> _mockAcademyGateway;
+        private GetTaxPayerByIdUseCase _classUnderTest;
+        private readonly Fixture _fixture = new Fixture();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockAcademyGateway = new Mock<IAcademyGateway>();
+            _classUnderTest = new GetTaxPayerByIdUseCase(_mockAcademyGateway.Object);
+        }
+
+        [Test]
+        public void ReturnsATaxPayerInformationRecordForTheSpecifiedAccountRef()
+        {
+            var stubbedTaxPayerInfo = _fixture.Create<TaxPayerInformation>();
+
+            _mockAcademyGateway.Setup(x =>
+                    x.GetTaxPayerById(67890))
+                .Returns(stubbedTaxPayerInfo);
+
+            var response = _classUnderTest.Execute(67890);
+            var expectedResponse = stubbedTaxPayerInfo.ToResponse();
+
+            response.Should().NotBeNull();
+            response.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
+        public void IfGatewayReturnsNullThrowNotFoundException()
+        {
+            TaxPayerInformation nullResult = null;
+
+            _mockAcademyGateway.Setup(x =>
+                    x.GetTaxPayerById(It.IsAny<int>()))
+                .Returns(nullResult);
+
+            Func<TaxPayerInformationResponse> testDelegate = () => _classUnderTest.Execute(456);
+            testDelegate.Should().Throw<TaxPayerNotFoundException>();
+        }
+    }
+}

--- a/AcademyResidentInformationApi/Startup.cs
+++ b/AcademyResidentInformationApi/Startup.cs
@@ -125,6 +125,7 @@ namespace AcademyResidentInformationApi
         {
             services.AddScoped<IGetAllClaimantsUseCase, GetAllClaimantsUseCase>();
             services.AddScoped<IGetClaimantByIdUseCase, GetClaimantByIdUseCase>();
+            services.AddScoped<IGetTaxPayerByIdUseCase, GetTaxPayerByIdUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/AcademyResidentInformationApi/V1/Boundary/Responses/TaxPayerInformation.cs
+++ b/AcademyResidentInformationApi/V1/Boundary/Responses/TaxPayerInformation.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace AcademyResidentInformationApi.V1.Boundary.Responses
+{
+    public class TaxPayerInformationResponse
+    {
+        public int AccountRef { get; set; }
+        public string UPRN { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public List<string> EmailList { get; set; }
+        public List<string> PhoneNumberList { get; set; }
+        public Address TaxPayerAddress { get; set; }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Controllers/ClaimantsController.cs
+++ b/AcademyResidentInformationApi/V1/Controllers/ClaimantsController.cs
@@ -9,12 +9,12 @@ namespace AcademyResidentInformationApi.V1.Controllers
     [ApiVersion("1.0")]
     [Route("api/v1/claimants")]
     [Produces("application/json")]
-    public class AcademyController : BaseController
+    public class ClaimantsController : BaseController
     {
         private IGetAllClaimantsUseCase _getAllClaimantsUseCase;
         private readonly IGetClaimantByIdUseCase _getClaimantByIdUseCase;
 
-        public AcademyController(IGetAllClaimantsUseCase getAllClaimantsUseCase, IGetClaimantByIdUseCase getClaimantByIdUseCase)
+        public ClaimantsController(IGetAllClaimantsUseCase getAllClaimantsUseCase, IGetClaimantByIdUseCase getClaimantByIdUseCase)
         {
             _getAllClaimantsUseCase = getAllClaimantsUseCase;
             _getClaimantByIdUseCase = getClaimantByIdUseCase;

--- a/AcademyResidentInformationApi/V1/Controllers/TaxPayersController.cs
+++ b/AcademyResidentInformationApi/V1/Controllers/TaxPayersController.cs
@@ -1,0 +1,43 @@
+using AcademyResidentInformationApi.V1.UseCase.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using AcademyResidentInformationApi.V1.Boundary.Requests;
+using AcademyResidentInformationApi.V1.Domain;
+using AcademyResidentInformationApi.V1.UseCase;
+
+namespace AcademyResidentInformationApi.V1.Controllers
+{
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("api/v1/tax-payers")]
+    [Produces("application/json")]
+    public class TaxPayersController : BaseController
+    {
+        private readonly IGetTaxPayerByIdUseCase _getTaxPayerByIdUseCase;
+
+        public TaxPayersController(IGetTaxPayerByIdUseCase getTaxPayerByIdUseCase)
+        {
+            _getTaxPayerByIdUseCase = getTaxPayerByIdUseCase;
+        }
+
+        [HttpGet]
+        public IActionResult ListTaxPayers()
+        {
+            return Ok();
+        }
+
+        [HttpGet]
+        [Route("{accountRef}")]
+        public IActionResult ViewRecord(int accountRef)
+        {
+            try
+            {
+                var record = _getTaxPayerByIdUseCase.Execute(accountRef);
+                return Ok(record);
+            }
+            catch (TaxPayerNotFoundException)
+            {
+                return NotFound();
+            }
+        }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Domain/Address.cs
+++ b/AcademyResidentInformationApi/V1/Domain/Address.cs
@@ -1,0 +1,11 @@
+namespace AcademyResidentInformationApi.V1.Domain
+{
+    public class Address
+    {
+        public string AddressLine1 { get; set; }
+        public string AddressLine2 { get; set; }
+        public string AddressLine3 { get; set; }
+        public string AddressLine4 { get; set; }
+        public string PostCode { get; set; }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Domain/ClaimantInformation.cs
+++ b/AcademyResidentInformationApi/V1/Domain/ClaimantInformation.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace AcademyResidentInformationApi.V1.Domain
 {
     public class ClaimantInformation
@@ -18,14 +15,5 @@ namespace AcademyResidentInformationApi.V1.Domain
 
         public int MemberId { get; set; }
         public int HouseId { get; set; }
-    }
-
-    public class Address
-    {
-        public string AddressLine1 { get; set; }
-        public string AddressLine2 { get; set; }
-        public string AddressLine3 { get; set; }
-        public string AddressLine4 { get; set; }
-        public string PostCode { get; set; }
     }
 }

--- a/AcademyResidentInformationApi/V1/Domain/TaxPayerInformation.cs
+++ b/AcademyResidentInformationApi/V1/Domain/TaxPayerInformation.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace AcademyResidentInformationApi.V1.Domain
+{
+    public class TaxPayerInformation
+    {
+        public int AccountRef { get; set; }
+        public string Uprn { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public List<string> EmailList { get; set; }
+        public List<string> PhoneNumberList { get; set; }
+        public Address TaxPayerAddress { get; set; }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Domain/TaxPayerNotFoundException.cs
+++ b/AcademyResidentInformationApi/V1/Domain/TaxPayerNotFoundException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace AcademyResidentInformationApi.V1.Domain
+{
+    public class TaxPayerNotFoundException : Exception
+    {
+        public TaxPayerNotFoundException() { }
+        public TaxPayerNotFoundException(string message) : base(message)
+        { }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Factories/EntityFactory.cs
+++ b/AcademyResidentInformationApi/V1/Factories/EntityFactory.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
+using AcademyResidentInformationApi.V1.Domain;
 using AcademyResidentInformationApi.V1.Infrastructure;
 using Address = AcademyResidentInformationApi.V1.Domain.Address;
 using ClaimantInformation = AcademyResidentInformationApi.V1.Domain.ClaimantInformation;
@@ -43,6 +43,16 @@ namespace AcademyResidentInformationApi.V1.Factories
                 AddressLine3 = databaseEntity.AddressLine3,
                 AddressLine4 = databaseEntity.AddressLine4,
                 PostCode = databaseEntity.PostCode
+            };
+        }
+
+        public static TaxPayerInformation ToDomain(this TaxPayer databaseEntity)
+        {
+            return new TaxPayerInformation
+            {
+                AccountRef = databaseEntity.AccountRef,
+                FirstName = databaseEntity.FirstName,
+                LastName = databaseEntity.LastName
             };
         }
     }

--- a/AcademyResidentInformationApi/V1/Factories/EntityFactory.cs
+++ b/AcademyResidentInformationApi/V1/Factories/EntityFactory.cs
@@ -55,5 +55,17 @@ namespace AcademyResidentInformationApi.V1.Factories
                 LastName = databaseEntity.LastName
             };
         }
+
+        public static Address ToDomain(this CouncilProperty databaseEntity)
+        {
+            return new Address
+            {
+                AddressLine1 = databaseEntity.AddressLine1,
+                AddressLine2 = databaseEntity.AddressLine2,
+                AddressLine3 = databaseEntity.AddressLine3,
+                AddressLine4 = databaseEntity.AddressLine4,
+                PostCode = databaseEntity.PostCode
+            };
+        }
     }
 }

--- a/AcademyResidentInformationApi/V1/Factories/ResponseFactory.cs
+++ b/AcademyResidentInformationApi/V1/Factories/ResponseFactory.cs
@@ -1,7 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
+using AcademyResidentInformationApi.V1.Boundary.Responses;
 using AcademyResidentInformationApi.V1.Domain;
+using Address = AcademyResidentInformationApi.V1.Domain.Address;
 using AddressResponse = AcademyResidentInformationApi.V1.Boundary.Responses.Address;
+using ClaimantInformation = AcademyResidentInformationApi.V1.Domain.ClaimantInformation;
 using ClaimantInformationResponse = AcademyResidentInformationApi.V1.Boundary.Responses.ClaimantInformation;
 
 
@@ -31,15 +34,29 @@ namespace AcademyResidentInformationApi.V1.Factories
             return people.Select(p => p.ToResponse()).ToList();
         }
 
-        private static AddressResponse ToResponse(this Address claimantAddress)
+        public static TaxPayerInformationResponse ToResponse(this TaxPayerInformation taxPayerInfo)
+        {
+            return new TaxPayerInformationResponse
+            {
+                AccountRef = taxPayerInfo.AccountRef,
+                UPRN = taxPayerInfo.Uprn,
+                EmailList = taxPayerInfo.EmailList,
+                PhoneNumberList = taxPayerInfo.PhoneNumberList,
+                FirstName = taxPayerInfo.FirstName,
+                LastName = taxPayerInfo.LastName,
+                TaxPayerAddress = taxPayerInfo.TaxPayerAddress.ToResponse()
+            };
+        }
+
+        private static AddressResponse ToResponse(this Address domainAddress)
         {
             return new AddressResponse()
             {
-                AddressLine1 = claimantAddress.AddressLine1,
-                AddressLine2 = claimantAddress.AddressLine2,
-                AddressLine3 = claimantAddress.AddressLine3,
-                AddressLine4 = claimantAddress.AddressLine4,
-                Postcode = claimantAddress.PostCode
+                AddressLine1 = domainAddress.AddressLine1,
+                AddressLine2 = domainAddress.AddressLine2,
+                AddressLine3 = domainAddress.AddressLine3,
+                AddressLine4 = domainAddress.AddressLine4,
+                Postcode = domainAddress.PostCode
             };
         }
     }

--- a/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
@@ -74,8 +74,6 @@ namespace AcademyResidentInformationApi.V1.Gateways
 
         public TaxPayerInformation GetTaxPayerById(int accountRef)
         {
-            // var databaseRecord = _academyContext.TaxPayers.FirstOrDefault(tp => tp.AccountRef == accountRef);
-
             var taxPayerRecord = _academyContext.TaxPayers.FirstOrDefault(tp => tp.AccountRef == accountRef);
 
             if (taxPayerRecord == null) return null;
@@ -84,7 +82,11 @@ namespace AcademyResidentInformationApi.V1.Gateways
 
             var propertyDetails = _academyContext.CouncilProperties.FirstOrDefault(cp => cp.PropertyRef == occupationDetails.PropertyRef);
 
-            return MapDetailsToTaxPayerInformation(taxPayerRecord, propertyDetails);
+            var emailDetails = _academyContext.Emails.FirstOrDefault(email => email.ReferenceId.Equals(accountRef));
+            var phoneDetails = _academyContext.PhoneNumbers.FirstOrDefault(phone => phone.Reference == accountRef.ToString());
+
+
+            return MapDetailsToTaxPayerInformation(taxPayerRecord, propertyDetails, emailDetails, phoneDetails);
         }
 
         private static ClaimantInformation MapPersonAndAddressesToClaimantInformation(Person person, Address address)
@@ -94,11 +96,15 @@ namespace AcademyResidentInformationApi.V1.Gateways
             return claimant;
         }
 
-        private TaxPayerInformation MapDetailsToTaxPayerInformation(TaxPayer taxPayer, CouncilProperty propertyInfo)
+        private TaxPayerInformation MapDetailsToTaxPayerInformation(TaxPayer taxPayer, CouncilProperty propertyInfo, Email email, PhoneNumber phoneNumbers)
         {
             var person = taxPayer.ToDomain();
             person.Uprn = propertyInfo?.Uprn;
             person.TaxPayerAddress = propertyInfo?.ToDomain();
+            person.EmailList = new List<string> { email?.EmailAddress };
+            person.PhoneNumberList = new List<string> { phoneNumbers?.Number1, phoneNumbers?.Number2, phoneNumbers?.Number3, phoneNumbers?.Number4 };
+
+            person.PhoneNumberList.RemoveAll(item => item == null);
 
             return person;
         }

--- a/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
@@ -78,7 +78,11 @@ namespace AcademyResidentInformationApi.V1.Gateways
 
             var propertyDetails = _academyContext.CouncilProperties.FirstOrDefault(cp => cp.PropertyRef == occupationDetails.PropertyRef);
 
-            var emailDetails = _academyContext.Emails.FirstOrDefault(email => email.ReferenceId.Equals(accountRef));
+            var emailDetails = _academyContext.Emails
+                .Where(email => email.ReferenceId.Equals(accountRef))
+                .GroupBy(x => x.EmailAddress)
+                .Select(x => x.Key)
+                .ToList();
             var phoneDetails = _academyContext.PhoneNumbers.FirstOrDefault(phone => phone.Reference == accountRef.ToString());
 
 
@@ -92,12 +96,12 @@ namespace AcademyResidentInformationApi.V1.Gateways
             return claimant;
         }
 
-        private static TaxPayerInformation MapDetailsToTaxPayerInformation(TaxPayer taxPayer, CouncilProperty propertyInfo, Email email, PhoneNumber phoneNumbers)
+        private static TaxPayerInformation MapDetailsToTaxPayerInformation(TaxPayer taxPayer, CouncilProperty propertyInfo, List<string> emails, PhoneNumber phoneNumbers)
         {
             var person = taxPayer.ToDomain();
             person.Uprn = propertyInfo?.Uprn;
             person.TaxPayerAddress = propertyInfo?.ToDomain();
-            person.EmailList = new List<string> { email?.EmailAddress };
+            person.EmailList = emails;
             person.PhoneNumberList = new List<string> { phoneNumbers?.Number1, phoneNumbers?.Number2, phoneNumbers?.Number3, phoneNumbers?.Number4 };
 
             person.PhoneNumberList.RemoveAll(item => item == null);

--- a/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
@@ -53,10 +53,6 @@ namespace AcademyResidentInformationApi.V1.Gateways
                 }
                 ).Take(limit).ToList().ToDomain();
         }
-        private static string GetSearchPattern(string str)
-        {
-            return $"%{str?.Replace(" ", "")}%";
-        }
 
         public ClaimantInformation GetClaimantById(int claimId, int personRef)
         {
@@ -96,7 +92,7 @@ namespace AcademyResidentInformationApi.V1.Gateways
             return claimant;
         }
 
-        private TaxPayerInformation MapDetailsToTaxPayerInformation(TaxPayer taxPayer, CouncilProperty propertyInfo, Email email, PhoneNumber phoneNumbers)
+        private static TaxPayerInformation MapDetailsToTaxPayerInformation(TaxPayer taxPayer, CouncilProperty propertyInfo, Email email, PhoneNumber phoneNumbers)
         {
             var person = taxPayer.ToDomain();
             person.Uprn = propertyInfo?.Uprn;
@@ -107,6 +103,11 @@ namespace AcademyResidentInformationApi.V1.Gateways
             person.PhoneNumberList.RemoveAll(item => item == null);
 
             return person;
+        }
+
+        private static string GetSearchPattern(string str)
+        {
+            return $"%{str?.Replace(" ", "")}%";
         }
     }
 }

--- a/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
@@ -78,5 +78,12 @@ namespace AcademyResidentInformationApi.V1.Gateways
             claimant.ClaimantAddress = address.ToDomain();
             return claimant;
         }
+
+        public TaxPayerInformation GetTaxPayerById(int accountRef)
+        {
+            var databaseRecord = _academyContext.TaxPayers.FirstOrDefault(tp => tp.AccountRef == accountRef);
+
+            return databaseRecord?.ToDomain();
+        }
     }
 }

--- a/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/AcademyGateway.cs
@@ -72,6 +72,21 @@ namespace AcademyResidentInformationApi.V1.Gateways
                 : MapPersonAndAddressesToClaimantInformation(databaseRecord.person, databaseRecord.address);
         }
 
+        public TaxPayerInformation GetTaxPayerById(int accountRef)
+        {
+            // var databaseRecord = _academyContext.TaxPayers.FirstOrDefault(tp => tp.AccountRef == accountRef);
+
+            var taxPayerRecord = _academyContext.TaxPayers.FirstOrDefault(tp => tp.AccountRef == accountRef);
+
+            if (taxPayerRecord == null) return null;
+
+            var occupationDetails = _academyContext.Occupations.FirstOrDefault(cto => cto.AccountRef.Equals(taxPayerRecord.AccountRef));
+
+            var propertyDetails = _academyContext.CouncilProperties.FirstOrDefault(cp => cp.PropertyRef == occupationDetails.PropertyRef);
+
+            return MapDetailsToTaxPayerInformation(taxPayerRecord, propertyDetails);
+        }
+
         private static ClaimantInformation MapPersonAndAddressesToClaimantInformation(Person person, Address address)
         {
             var claimant = person.ToDomain();
@@ -79,11 +94,13 @@ namespace AcademyResidentInformationApi.V1.Gateways
             return claimant;
         }
 
-        public TaxPayerInformation GetTaxPayerById(int accountRef)
+        private TaxPayerInformation MapDetailsToTaxPayerInformation(TaxPayer taxPayer, CouncilProperty propertyInfo)
         {
-            var databaseRecord = _academyContext.TaxPayers.FirstOrDefault(tp => tp.AccountRef == accountRef);
+            var person = taxPayer.ToDomain();
+            person.Uprn = propertyInfo?.Uprn;
+            person.TaxPayerAddress = propertyInfo?.ToDomain();
 
-            return databaseRecord?.ToDomain();
+            return person;
         }
     }
 }

--- a/AcademyResidentInformationApi/V1/Gateways/IAcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/IAcademyGateway.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using AcademyResidentInformationApi.V1.Domain;
+using AcademyResidentInformationApi.V1.Infrastructure;
 using ClaimantInformation = AcademyResidentInformationApi.V1.Domain.ClaimantInformation;
 
 namespace AcademyResidentInformationApi.V1.Gateways
@@ -9,6 +10,7 @@ namespace AcademyResidentInformationApi.V1.Gateways
         List<ClaimantInformation> GetAllClaimants(Cursor cursor, int limit, string firstname = null,
             string lastname = null, string postcode = null, string address = null);
         ClaimantInformation GetClaimantById(int claimId, int personRef);
+        TaxPayerInformation GetTaxPayerById(int accountRef);
     }
 
 }

--- a/AcademyResidentInformationApi/V1/Gateways/IAcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/IAcademyGateway.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using AcademyResidentInformationApi.V1.Boundary.Responses;
 using AcademyResidentInformationApi.V1.Domain;
 using ClaimantInformation = AcademyResidentInformationApi.V1.Domain.ClaimantInformation;
 

--- a/AcademyResidentInformationApi/V1/Infrastructure/AcademyContext.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/AcademyContext.cs
@@ -16,6 +16,10 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
         public DbSet<CouncilProperty> CouncilProperties { get; set; }
         public DbSet<Occupation> Occupations { get; set; }
 
+        public DbSet<Email> Emails { get; set; }
+
+        public DbSet<PhoneNumber> PhoneNumbers { get; set; }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             // composite primary key for Address table

--- a/AcademyResidentInformationApi/V1/Infrastructure/AcademyContext.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/AcademyContext.cs
@@ -12,6 +12,7 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
         public DbSet<Address> Addresses { get; set; }
 
         public DbSet<Claim> Claims { get; set; }
+        public DbSet<TaxPayer> TaxPayers { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/AcademyResidentInformationApi/V1/Infrastructure/AcademyContext.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/AcademyContext.cs
@@ -13,6 +13,8 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
 
         public DbSet<Claim> Claims { get; set; }
         public DbSet<TaxPayer> TaxPayers { get; set; }
+        public DbSet<CouncilProperty> CouncilProperties { get; set; }
+        public DbSet<Occupation> Occupations { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/AcademyResidentInformationApi/V1/Infrastructure/CouncilProperty.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/CouncilProperty.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AcademyResidentInformationApi.V1.Infrastructure
+{
+    [Table("ctproperty", Schema = "dbo")]
+    public class CouncilProperty
+    {
+        [Column("property_ref")]
+        public string PropertyRef { get; set; }
+
+        [Column("addr1")]
+        public string AddressLine1 { get; set; }
+
+        [Column("addr2")]
+        public string AddressLine2 { get; set; }
+
+        [Column("addr3")]
+        public string AddressLine3 { get; set; }
+
+        [Column("addr4")]
+        public string AddressLine4 { get; set; }
+
+        [Column("postcode")]
+        public string PostCode { get; set; }
+
+        [Column("uprn")]
+        public string Uprn { get; set; }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Infrastructure/CouncilProperty.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/CouncilProperty.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AcademyResidentInformationApi.V1.Infrastructure
@@ -5,25 +6,33 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
     [Table("ctproperty", Schema = "dbo")]
     public class CouncilProperty
     {
+        [Key]
         [Column("property_ref")]
+        [MaxLength(18)]
         public string PropertyRef { get; set; }
 
         [Column("addr1")]
+        [MaxLength(35)]
         public string AddressLine1 { get; set; }
 
         [Column("addr2")]
+        [MaxLength(35)]
         public string AddressLine2 { get; set; }
 
         [Column("addr3")]
+        [MaxLength(32)]
         public string AddressLine3 { get; set; }
 
         [Column("addr4")]
+        [MaxLength(32)]
         public string AddressLine4 { get; set; }
 
         [Column("postcode")]
+        [MaxLength(8)]
         public string PostCode { get; set; }
 
         [Column("uprn")]
+        [MaxLength(12)]
         public string Uprn { get; set; }
     }
 }

--- a/AcademyResidentInformationApi/V1/Infrastructure/Email.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/Email.cs
@@ -11,6 +11,7 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
         public int ReferenceId { get; set; }
 
         [Column("email_addr")]
+        [MaxLength(128)]
         public string EmailAddress { get; set; }
     }
 }

--- a/AcademyResidentInformationApi/V1/Infrastructure/Email.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/Email.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AcademyResidentInformationApi.V1.Infrastructure
+{
+    [Table("syemail", Schema = "dbo")]
+    public class Email
+    {
+        [Column("reference_id")]
+        public int ReferenceId { get; set; }
+
+        [Column("email_addr")]
+        public string EmailAddress { get; set; }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Infrastructure/Email.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/Email.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AcademyResidentInformationApi.V1.Infrastructure
@@ -5,6 +6,7 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
     [Table("syemail", Schema = "dbo")]
     public class Email
     {
+        [Key]
         [Column("reference_id")]
         public int ReferenceId { get; set; }
 

--- a/AcademyResidentInformationApi/V1/Infrastructure/Occupation.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/Occupation.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AcademyResidentInformationApi.V1.Infrastructure
+{
+    [Table("ctoccupation", Schema = "dbo")]
+    public class Occupation
+    {
+        [Key]
+        [Column("account_ref")]
+        public int AccountRef { get; set; }
+
+        [Column("property_ref")]
+        [MaxLength(18)]
+        public string PropertyRef { get; set; }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Infrastructure/PhoneNumber.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/PhoneNumber.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AcademyResidentInformationApi.V1.Infrastructure
@@ -6,6 +7,7 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
     [Table("syphone", Schema = "dbo")]
     public class PhoneNumber
     {
+        [Key]
         [Column("ref")]
         public string Reference { get; set; }
 

--- a/AcademyResidentInformationApi/V1/Infrastructure/PhoneNumber.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/PhoneNumber.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AcademyResidentInformationApi.V1.Infrastructure
+{
+
+    [Table("syphone", Schema = "dbo")]
+    public class PhoneNumber
+    {
+        [Column("ref")]
+        public string Reference { get; set; }
+
+        [Column("phonenum1")]
+        public string Number1 { get; set; }
+
+        [Column("phonenum2")]
+        public string Number2 { get; set; }
+
+        [Column("phonenum3")]
+        public string Number3 { get; set; }
+
+        [Column("phonenum4")]
+        public string Number4 { get; set; }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Infrastructure/PhoneNumber.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/PhoneNumber.cs
@@ -12,14 +12,18 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
         public string Reference { get; set; }
 
         [Column("phonenum1")]
+        [MaxLength(20)]
         public string Number1 { get; set; }
 
+        [MaxLength(20)]
         [Column("phonenum2")]
         public string Number2 { get; set; }
 
+        [MaxLength(20)]
         [Column("phonenum3")]
         public string Number3 { get; set; }
 
+        [MaxLength(20)]
         [Column("phonenum4")]
         public string Number4 { get; set; }
     }

--- a/AcademyResidentInformationApi/V1/Infrastructure/TaxPayer.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/TaxPayer.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AcademyResidentInformationApi.V1.Infrastructure
+{
+    [Table("ctaccount", Schema = "dbo")]
+    public class TaxPayer
+    {
+        [Key]
+        [Column("account_ref")]
+        public int AccountRef { get; set; }
+
+        [Column("lead_liab_forename")]
+        [MaxLength(32)]
+        public string FirstName { get; set; }
+
+        [Column("lead_liab_surname")]
+        [MaxLength(32)]
+        public string LastName { get; set; }
+    }
+}

--- a/AcademyResidentInformationApi/V1/UseCase/GetTaxPayerByIdUseCase.cs
+++ b/AcademyResidentInformationApi/V1/UseCase/GetTaxPayerByIdUseCase.cs
@@ -1,0 +1,23 @@
+using AcademyResidentInformationApi.V1.Boundary.Responses;
+using AcademyResidentInformationApi.V1.Domain;
+using AcademyResidentInformationApi.V1.Factories;
+using AcademyResidentInformationApi.V1.Gateways;
+
+namespace AcademyResidentInformationApi.V1.UseCase
+{
+    public class GetTaxPayerByIdUseCase : IGetTaxPayerByIdUseCase
+    {
+        private readonly IAcademyGateway _academyGateway;
+        public GetTaxPayerByIdUseCase(IAcademyGateway academyGateway)
+        {
+            _academyGateway = academyGateway;
+        }
+
+        public TaxPayerInformationResponse Execute(int accountRef)
+        {
+            var payerInfo = _academyGateway.GetTaxPayerById(accountRef);
+            if (payerInfo == null) throw new TaxPayerNotFoundException();
+            return payerInfo.ToResponse();
+        }
+    }
+}

--- a/AcademyResidentInformationApi/V1/UseCase/Interfaces/IGetTaxPayerByIdUseCase.cs
+++ b/AcademyResidentInformationApi/V1/UseCase/Interfaces/IGetTaxPayerByIdUseCase.cs
@@ -1,0 +1,9 @@
+using AcademyResidentInformationApi.V1.Boundary.Responses;
+
+namespace AcademyResidentInformationApi.V1.UseCase
+{
+    public interface IGetTaxPayerByIdUseCase
+    {
+        TaxPayerInformationResponse Execute(int accountRef);
+    }
+}


### PR DESCRIPTION
To Do:

- [x] Add controller endpoint and test(s)
- [x] Add End to End test(s) for taxpayer view endpoint
- [x] Check if a tax payer's email should be returned as a list or as a string (Check DB? Initial assumption was that there were multiple emails that could be saved but looking at the `syemail` table implies otherwise)
- [ ] Refactor & clean up code.
- [ ] Set up a canary + any other appropriate alerting

*Open to feedback, comments, suggestions* ☺️ 