### PR TITLE
List Endpoint for Council Tax Data

### DIFF
--- a/AcademyResidentInformationApi.Tests/V1/Controllers/ClaimantsControllerTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Controllers/ClaimantsControllerTests.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
+using AcademyResidentInformationApi.V1.Boundary.Requests;
 using AcademyResidentInformationApi.V1.Boundary.Responses;
 using AcademyResidentInformationApi.V1.Controllers;
+using AcademyResidentInformationApi.V1.Domain;
 using AcademyResidentInformationApi.V1.UseCase.Interfaces;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
-using AcademyResidentInformationApi.V1.Boundary.Requests;
-using AcademyResidentInformationApi.V1.Domain;
 using NUnit.Framework;
 using ClaimantInformation = AcademyResidentInformationApi.V1.Boundary.Responses.ClaimantInformation;
 
@@ -47,10 +47,10 @@ namespace AcademyResidentInformationApi.Tests.V1.Controllers
                 Claimants = claimantInfo
             };
 
-            var cqp = new ClaimantQueryParam();
+            var qp = new QueryParameters();
 
-            _mockGetAllClaimantsUseCase.Setup(x => x.Execute(cqp, null, 20)).Returns(claimantInformationList);
-            var response = _classUnderTest.ListContacts(cqp) as OkObjectResult;
+            _mockGetAllClaimantsUseCase.Setup(x => x.Execute(qp, null, 20)).Returns(claimantInformationList);
+            var response = _classUnderTest.ListContacts(qp) as OkObjectResult;
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(200);
@@ -60,10 +60,10 @@ namespace AcademyResidentInformationApi.Tests.V1.Controllers
         [Test]
         public void ListContactsReturns400IfUseCaseThrowsInvalidCursorException()
         {
-            _mockGetAllClaimantsUseCase.Setup(x => x.Execute(It.IsAny<ClaimantQueryParam>(), null, 20))
+            _mockGetAllClaimantsUseCase.Setup(x => x.Execute(It.IsAny<QueryParameters>(), null, 20))
                 .Throws(new InvalidCursorException("Wrong cursor"));
 
-            var response = _classUnderTest.ListContacts(new ClaimantQueryParam()) as BadRequestObjectResult;
+            var response = _classUnderTest.ListContacts(new QueryParameters()) as BadRequestObjectResult;
 
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(400);

--- a/AcademyResidentInformationApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/AcademyResidentInformationApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -69,7 +69,7 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
             context.Occupations.Add(occupation);
             context.SaveChanges();
 
-            var property = TestHelper.CreateDatabasePropertyForTaxPayer(occupation.PropertyRef);
+            var property = TestHelper.CreateDatabasePropertyForTaxPayer(occupation.PropertyRef, addressLines, postcode);
             context.CouncilProperties.Add(property);
             context.SaveChanges();
 

--- a/AcademyResidentInformationApi.Tests/V1/E2ETests/ListClaimantsReturnsAListOfAllClaimants.cs
+++ b/AcademyResidentInformationApi.Tests/V1/E2ETests/ListClaimantsReturnsAListOfAllClaimants.cs
@@ -21,7 +21,7 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
         }
 
         [Test]
-        public async Task IfNoQueryParametersListClaimantsReturnsAllClaimantRecordInAcademy()
+        public async Task IfNoQueryParametersetersListClaimantsReturnsAllClaimantRecordInAcademy()
         {
             var expectedClaimantResponseOne = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext);
             var expectedClaimantResponseTwo = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext);
@@ -42,7 +42,7 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
             convertedResponse.Claimants.Should().ContainEquivalentOf(expectedClaimantResponseThree);
         }
         [Test]
-        public async Task FirstNameLastNameQueryParametersReturnsMatchingClaimantRecordsFromAcademy()
+        public async Task FirstNameLastNameQueryParametersetersReturnsMatchingClaimantRecordsFromAcademy()
         {
             var expectedClaimantResponseOne = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "tessellate");
             var expectedClaimantResponseTwo = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "shape");
@@ -64,7 +64,7 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
             convertedResponse.Claimants.Should().ContainEquivalentOf(expectedClaimantResponseOne);
         }
         [Test]
-        public async Task FirstNameLastNameQueryParametersWildcardSearchReturnsMatchingClaimantRecordsFromAcademy()
+        public async Task FirstNameLastNameQueryParametersetersWildcardSearchReturnsMatchingClaimantRecordsFromAcademy()
         {
             var expectedClaimantResponseOne = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "tessellate");
             var expectedClaimantResponseTwo = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "shape");
@@ -86,7 +86,7 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
             convertedResponse.Claimants.Should().ContainEquivalentOf(expectedClaimantResponseOne);
         }
         [Test]
-        public async Task PostcodeAndAddressQueryParametersReturnsMatchingClaimantsRecordsFromAcademy()
+        public async Task PostcodeAndAddressQueryParametersetersReturnsMatchingClaimantsRecordsFromAcademy()
         {
             var matchingClaimantOne = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR", addressLines: "1 Seasame street, Hackney, LDN");
             var matchingClaimantTwo = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR", addressLines: "1 Seasame street");
@@ -110,7 +110,7 @@ namespace AcademyResidentInformationApi.Tests.V1.E2ETests
         }
 
         [Test]
-        public async Task UsingAllQueryParametersReturnsMatchingClaimantsRecordsFromAcademy()
+        public async Task UsingAllQueryParametersetersReturnsMatchingClaimantsRecordsFromAcademy()
         {
             var matchingClaimantOne = E2ETestHelpers.AddClaimantWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR",
                 addressLines: "1 Seasame street, Hackney, LDN", firstname: "ciasom", lastname: "shape");

--- a/AcademyResidentInformationApi.Tests/V1/E2ETests/ListTaxPayersReturnsAListOfTaxPayers.cs
+++ b/AcademyResidentInformationApi.Tests/V1/E2ETests/ListTaxPayersReturnsAListOfTaxPayers.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Threading.Tasks;
+using AcademyResidentInformationApi.V1.Boundary.Responses;
+using AutoFixture;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace AcademyResidentInformationApi.Tests.V1.E2ETests
+{
+    public class ListTaxPayersReturnsAListOfTaxPayers : IntegrationTests<Startup>
+    {
+        private IFixture _fixture;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Test]
+        public async Task IfNoQueryParametersetersListListTaxPayersReturnsAllTaxPayerRecordsInAcademy()
+        {
+            var databaseEntity1 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext);
+            var databaseEntity2 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext);
+            var databaseEntity3 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext);
+
+            var listUri = new Uri("api/v1/tax-payers", UriKind.Relative);
+
+            var response = Client.GetAsync(listUri);
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<TaxPayerInformationList>(stringContent);
+
+            convertedResponse.TaxPayers.Should().ContainEquivalentOf(databaseEntity1);
+            convertedResponse.TaxPayers.Should().ContainEquivalentOf(databaseEntity2);
+            convertedResponse.TaxPayers.Should().ContainEquivalentOf(databaseEntity3);
+        }
+
+        [Test]
+        public async Task FirstNameLastNameQueryParametersetersReturnsMatchingTaxPayerRecordsFromAcademy()
+        {
+            var databaseEntity1 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "tessellate");
+            var databaseEntity2 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "shape");
+            var databaseEntity3 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext);
+
+            var queryUri = new Uri("api/v1/tax-payers?first_name=ciasom&last_name=tessellate", UriKind.Relative);
+
+            var response = Client.GetAsync(queryUri);
+
+            var statusCode = response.Result.StatusCode;
+
+            statusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<TaxPayerInformationList>(stringContent);
+
+            convertedResponse.TaxPayers.Count.Should().Be(1);
+            convertedResponse.TaxPayers.Should().ContainEquivalentOf(databaseEntity1);
+        }
+
+        [Test]
+        public async Task FirstNameLastNameQueryParametersetersWildcardSearchReturnsMatchingTaxPayerRecordsFromAcademy()
+        {
+            var databaseEntity1 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "tessellate");
+            var databaseEntity2 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, firstname: "ciasom", lastname: "shape");
+            var databaseEntity3 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext);
+
+            var queryUri = new Uri("api/v1/tax-payers?first_name=iasom&last_name=essellat", UriKind.Relative);
+
+            var response = Client.GetAsync(queryUri);
+
+            var statusCode = response.Result.StatusCode;
+
+            statusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<TaxPayerInformationList>(stringContent);
+
+            convertedResponse.TaxPayers.Count.Should().Be(1);
+            convertedResponse.TaxPayers.Should().ContainEquivalentOf(databaseEntity1);
+        }
+
+        [Test]
+        public async Task PostcodeAndAddressQueryParametersetersReturnsMatchingTaxPayerRecordsFromAcademy()
+        {
+            var databaseEntity1 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR", addressLines: "1 Seasame street, Hackney, LDN");
+            var databaseEntity2 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR", addressLines: "1 Seasame street");
+            var nonMatchingDatabaseEntity1 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, postcode: "E4 1RR");
+            var nonMatchingDatabaseEntity2 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, addressLines: "1 Seasame street, Hackney, LDN", postcode: "E4 1RR");
+            var nonMatchingDatabaseEntity3 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext);
+
+            var queryUri = new Uri("api/v1/tax-payers?postcode=e91rr&address=1 Seasame street", UriKind.Relative);
+
+            var response = Client.GetAsync(queryUri);
+
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<TaxPayerInformationList>(stringContent);
+
+            convertedResponse.TaxPayers.Should().ContainEquivalentOf(databaseEntity1);
+            convertedResponse.TaxPayers.Should().ContainEquivalentOf(databaseEntity2);
+        }
+
+        [Test]
+        public async Task UsingAllQueryParametersetersReturnsMatchingTaxPayerssRecordsFromAcademy()
+        {
+            var databaseEntity1 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, postcode: "E9 1RR",
+                addressLines: "1 Seasame street, Hackney, LDN", firstname: "ciasom", lastname: "shape");
+            var nonMatchingDatabaseEntity1 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, postcode: "E4 1RR", addressLines: "1 Seasame street", lastname: "shap");
+            var nonMatchingDatabaseEntity2 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, postcode: "E4 1RR", firstname: "ciasom");
+            var nonMatchingDatabaseEntity3 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext, addressLines: "1 Seasame street, Hackney, LDN", postcode: "E4 1RR");
+            var nonMatchingDatabaseEntity4 = E2ETestHelpers.AddTaxPayerWithRelatesEntitiesToDb(AcademyContext);
+
+            var queryUri = new Uri("api/v1/tax-payers?postcode=e91rr&address=1 Seasame street&first_name=ciasom&last_name=shape", UriKind.Relative);
+            var response = Client.GetAsync(queryUri);
+
+            var statusCode = response.Result.StatusCode;
+            statusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<TaxPayerInformationList>(stringContent);
+
+            convertedResponse.TaxPayers.Count.Should().Be(1);
+            convertedResponse.TaxPayers.Should().ContainEquivalentOf(databaseEntity1);
+        }
+    }
+}

--- a/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyGatewayTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Gateways/AcademyGatewayTests.cs
@@ -154,7 +154,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetAllResidentsWithFirstNameQueryParameterReturnsMatchingResident()
+        public void GetAllResidentsWithFirstNameQueryParameterseterReturnsMatchingResident()
         {
             var databaseEntity = AddPersonRecordToDatabase(firstname: "ciasom");
             var databaseEntity1 = AddPersonRecordToDatabase(firstname: "shape");
@@ -178,7 +178,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetAllResidentsWildcardSearchWithFirstNameQueryParameterReturnsMatchingResident()
+        public void GetAllResidentsWildcardSearchWithFirstNameQueryParameterseterReturnsMatchingResident()
         {
             var databaseEntity = AddPersonRecordToDatabase(firstname: "ciasom");
             var databaseEntity1 = AddPersonRecordToDatabase(firstname: "shape");
@@ -210,7 +210,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetAllResidentsWithLastNameQueryParameterReturnsMatchingResident()
+        public void GetAllResidentsWithLastNameQueryParameterseterReturnsMatchingResident()
         {
             var databaseEntity = AddPersonRecordToDatabase(lastname: "tessellate");
             var databaseEntity1 = AddPersonRecordToDatabase(lastname: "square");
@@ -233,7 +233,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetAllResidentsWildcardSearchWithLastNameQueryParameterReturnsMatchingResident()
+        public void GetAllResidentsWildcardSearchWithLastNameQueryParameterseterReturnsMatchingResident()
         {
             var databaseEntity = AddPersonRecordToDatabase(lastname: "tessellate");
             var databaseEntity1 = AddPersonRecordToDatabase(lastname: "square");
@@ -264,7 +264,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetAllResidentsWithNameQueryParametersReturnsMatchingResidentOnlyOnce()
+        public void GetAllResidentsWithNameQueryParametersetersReturnsMatchingResidentOnlyOnce()
         {
             var databaseEntity = AddPersonRecordToDatabase(firstname: "ciasom", lastname: "Tessellate");
 
@@ -280,7 +280,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetAllResidentsWildcardSearchWithNameQueryParametersReturnsMatchingResidentOnlyOnce()
+        public void GetAllResidentsWildcardSearchWithNameQueryParametersetersReturnsMatchingResidentOnlyOnce()
         {
             var databaseEntity = AddPersonRecordToDatabase(firstname: "ciasom", lastname: "Tessellate");
 
@@ -296,7 +296,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetAllResidentsWithPostCodeQueryParameterReturnsMatchingResident()
+        public void GetAllResidentsWithPostCodeQueryParameterseterReturnsMatchingResident()
         {
             var databaseEntity = AddPersonRecordToDatabase();
             var databaseEntity1 = AddPersonRecordToDatabase();
@@ -318,7 +318,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         }
 
         [Test]
-        public void GetAllResidentsWithNameAndPostCodeQueryParameterReturnsMatchingResident()
+        public void GetAllResidentsWithNameAndPostCodeQueryParameterseterReturnsMatchingResident()
         {
             var databaseEntity = AddPersonRecordToDatabase(firstname: "ciasom");
             var address = TestHelper.CreateDatabaseAddressForPersonId(databaseEntity.ClaimId, databaseEntity.HouseId, "E8 1DY");
@@ -347,7 +347,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
 
         [TestCase("E81DY")]
         [TestCase("e8 1DY")]
-        public void GetAllResidentsWithPostCodeQueryParameterIgnoresFormatting(string postcode)
+        public void GetAllResidentsWithPostCodeQueryParameterseterIgnoresFormatting(string postcode)
         {
             var databaseEntity = AddPersonRecordToDatabase();
             var address = AddAddressToDatabase(databaseEntity.ClaimId, databaseEntity.HouseId, postcode: postcode);
@@ -366,7 +366,7 @@ namespace AcademyResidentInformationApi.Tests.V1.Gateways
         [TestCase("My Street")]
         [TestCase("1 My Street, Hackney, London")]
         [TestCase("Hackney")]
-        public void GetAllResidentsWithAddressQueryParameterReturnsMatchingResident(string addressQuery)
+        public void GetAllResidentsWithAddressQueryParameterseterReturnsMatchingResident(string addressQuery)
         {
             var databaseEntity = AddPersonRecordToDatabase();
             var databaseEntity1 = AddPersonRecordToDatabase();

--- a/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/AcademyResidentInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -68,12 +68,14 @@ namespace AcademyResidentInformationApi.Tests.V1.Helper
             return tp;
         }
 
-        public static CouncilProperty CreateDatabasePropertyForTaxPayer(string propertyRef)
+        public static CouncilProperty CreateDatabasePropertyForTaxPayer(string propertyRef, string address = null, string postcode = null)
         {
             var faker = new Fixture();
             var cp = faker.Build<CouncilProperty>()
                 .With(p => p.PropertyRef, propertyRef)
                 .Create();
+            cp.AddressLine1 = address ?? cp.AddressLine1;
+            cp.PostCode = postcode ?? cp.PostCode;
             return cp;
         }
 
@@ -93,7 +95,9 @@ namespace AcademyResidentInformationApi.Tests.V1.Helper
                 .With(email => email.ReferenceId, accountRef)
                 .Create();
 
-            fakeEmail.EmailAddress = email ?? fakeEmail.EmailAddress;
+            if (email == null) return fakeEmail;
+
+            fakeEmail.EmailAddress = email;
 
             return fakeEmail;
         }

--- a/AcademyResidentInformationApi.Tests/V1/UseCase/GetAllClaimantsUseCaseTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/UseCase/GetAllClaimantsUseCaseTests.cs
@@ -1,15 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using AcademyResidentInformationApi.V1.Boundary.Requests;
+using AcademyResidentInformationApi.V1.Boundary.Responses;
+using AcademyResidentInformationApi.V1.Domain;
 using AcademyResidentInformationApi.V1.Factories;
 using AcademyResidentInformationApi.V1.Gateways;
 using AcademyResidentInformationApi.V1.UseCase;
 using AutoFixture;
 using FluentAssertions;
 using Moq;
-using AcademyResidentInformationApi.V1.Boundary.Requests;
-using AcademyResidentInformationApi.V1.Boundary.Responses;
-using AcademyResidentInformationApi.V1.Domain;
 using NUnit.Framework;
 using ClaimantInformation = AcademyResidentInformationApi.V1.Domain.ClaimantInformation;
 
@@ -38,14 +38,14 @@ namespace AcademyResidentInformationApi.Tests.V1.UseCase
                 x.GetAllClaimants(It.IsAny<Cursor>(), 20, "ciasom", "tessellate", "E8 1DY", "1 Montage street"))
                 .Returns(stubbedClaimants);
 
-            var cqp = new ClaimantQueryParam
+            var qp = new QueryParameters
             {
                 FirstName = "ciasom",
                 LastName = "tessellate",
                 Postcode = "E8 1DY",
                 Address = "1 Montage street"
             };
-            var response = _classUnderTest.Execute(cqp, null, 20);
+            var response = _classUnderTest.Execute(qp, null, 20);
 
             response.Should().NotBeNull();
             response.Claimants.Should().BeEquivalentTo(stubbedClaimants.ToResponse());
@@ -60,7 +60,7 @@ namespace AcademyResidentInformationApi.Tests.V1.UseCase
                 x.GetAllClaimants(It.IsAny<Cursor>(), 100, null, null, null, null))
                 .Returns(stubbedClaimants.ToList()).Verifiable();
 
-            _classUnderTest.Execute(new ClaimantQueryParam(), null, 101);
+            _classUnderTest.Execute(new QueryParameters(), null, 101);
 
             _mockAcademyGateway.Verify();
         }
@@ -74,7 +74,7 @@ namespace AcademyResidentInformationApi.Tests.V1.UseCase
                 x.GetAllClaimants(It.IsAny<Cursor>(), 10, null, null, null, null))
                 .Returns(stubbedClaimants.ToList()).Verifiable();
 
-            _classUnderTest.Execute(new ClaimantQueryParam(), null, 2);
+            _classUnderTest.Execute(new QueryParameters(), null, 2);
 
             _mockAcademyGateway.Verify();
         }
@@ -85,7 +85,7 @@ namespace AcademyResidentInformationApi.Tests.V1.UseCase
             var defaultCursor = new Cursor { ClaimId = 0, HouseId = 0, MemberId = 0 };
             _mockAcademyGateway.Setup(x => x.GetAllClaimants(CheckCursorIs(defaultCursor), 20, null, null, null, null))
                 .Returns(new List<ClaimantInformation>());
-            _classUnderTest.Execute(new ClaimantQueryParam(), null, 20);
+            _classUnderTest.Execute(new QueryParameters(), null, 20);
             _mockAcademyGateway.Verify();
         }
 
@@ -95,7 +95,7 @@ namespace AcademyResidentInformationApi.Tests.V1.UseCase
             var expectedCursor = new Cursor { ClaimId = 3400002, HouseId = 34, MemberId = 2 };
             _mockAcademyGateway.Setup(x => x.GetAllClaimants(CheckCursorIs(expectedCursor), 20, null, null, null, null))
                 .Returns(new List<ClaimantInformation>());
-            _classUnderTest.Execute(new ClaimantQueryParam(), "3400002-34-2", 20);
+            _classUnderTest.Execute(new QueryParameters(), "3400002-34-2", 20);
             _mockAcademyGateway.Verify();
         }
 
@@ -112,14 +112,14 @@ namespace AcademyResidentInformationApi.Tests.V1.UseCase
 
             _mockAcademyGateway.Setup(x => x.GetAllClaimants(It.IsAny<Cursor>(), 20, null, null, null, null))
                 .Returns(stubbedClaimants);
-            _classUnderTest.Execute(new ClaimantQueryParam(), null, 20).NextCursor.Should().Be("3400002-34-2");
+            _classUnderTest.Execute(new QueryParameters(), null, 20).NextCursor.Should().Be("3400002-34-2");
         }
 
         [Test]
         public void IfTheGivenCursorHasTheWrongFormatItThrows()
         {
             Func<ClaimantInformationList> testDelegate = () =>
-                _classUnderTest.Execute(new ClaimantQueryParam(), "222/78", 20);
+                _classUnderTest.Execute(new QueryParameters(), "222/78", 20);
             testDelegate.Should().Throw<InvalidCursorException>("The cursor provided is in the wrong format, please use the cursor provided in the previous response or if this is the first request leave it blank");
         }
 

--- a/AcademyResidentInformationApi.Tests/V1/UseCase/GetAllTaxPayersUseCaseTest.cs
+++ b/AcademyResidentInformationApi.Tests/V1/UseCase/GetAllTaxPayersUseCaseTest.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using AcademyResidentInformationApi.V1.Boundary.Requests;
+using AcademyResidentInformationApi.V1.Domain;
+using AcademyResidentInformationApi.V1.Factories;
+using AcademyResidentInformationApi.V1.Gateways;
+using AcademyResidentInformationApi.V1.UseCase;
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace AcademyResidentInformationApi.Tests.V1.UseCase
+{
+    public class GetAllTaxPayersUseCaseTest
+    {
+        private Mock<IAcademyGateway> _mockAcademyGateway;
+        private GetAllTaxPayersUseCase _classUnderTest;
+        private readonly Fixture _fixture = new Fixture();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockAcademyGateway = new Mock<IAcademyGateway>();
+            _classUnderTest = new GetAllTaxPayersUseCase(_mockAcademyGateway.Object);
+        }
+
+        [Test]
+        public void ReturnsTaxPayerInformationList()
+        {
+            var stubbedTaxPayers = _fixture.CreateMany<TaxPayerInformation>().ToList();
+
+            _mockAcademyGateway.Setup(x =>
+                x.GetAllTaxPayers("ciasom", "tessellate", "E8 1DY", "1 Montage street"))
+                .Returns(stubbedTaxPayers);
+
+            var qp = new QueryParameters
+            {
+                FirstName = "ciasom",
+                LastName = "tessellate",
+                Postcode = "E8 1DY",
+                Address = "1 Montage street"
+            };
+            var response = _classUnderTest.Execute(qp);
+            response.Should().NotBeNull();
+            response.TaxPayers.Should().BeEquivalentTo(stubbedTaxPayers.ToResponse());
+        }
+    }
+}

--- a/AcademyResidentInformationApi.Tests/V1/UseCase/GetClaimantByIdUseCaseTest.cs
+++ b/AcademyResidentInformationApi.Tests/V1/UseCase/GetClaimantByIdUseCaseTest.cs
@@ -1,3 +1,4 @@
+using System;
 using AcademyResidentInformationApi.V1.Domain;
 using AcademyResidentInformationApi.V1.Factories;
 using AcademyResidentInformationApi.V1.Gateways;
@@ -6,7 +7,6 @@ using AutoFixture;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
-using System;
 using ClaimantInformationResponse = AcademyResidentInformationApi.V1.Boundary.Responses.ClaimantInformation;
 
 namespace AcademyResidentInformationApi.Tests.V1.UseCase

--- a/AcademyResidentInformationApi.Tests/V1/UseCase/ValidatePostcodeTests.cs
+++ b/AcademyResidentInformationApi.Tests/V1/UseCase/ValidatePostcodeTests.cs
@@ -1,5 +1,5 @@
-using FluentAssertions;
 using AcademyResidentInformationApi.V1.UseCase;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace AcademyResidentInformationApi.Tests.V1.UseCase

--- a/AcademyResidentInformationApi/Startup.cs
+++ b/AcademyResidentInformationApi/Startup.cs
@@ -126,6 +126,7 @@ namespace AcademyResidentInformationApi
             services.AddScoped<IGetAllClaimantsUseCase, GetAllClaimantsUseCase>();
             services.AddScoped<IGetClaimantByIdUseCase, GetClaimantByIdUseCase>();
             services.AddScoped<IGetTaxPayerByIdUseCase, GetTaxPayerByIdUseCase>();
+            services.AddScoped<IGetAllTaxPayersUseCase, GetAllTaxPayersUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/AcademyResidentInformationApi/V1/Boundary/Requests/QueryParameters.cs
+++ b/AcademyResidentInformationApi/V1/Boundary/Requests/QueryParameters.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace AcademyResidentInformationApi.V1.Boundary.Requests
 {
-    public class ClaimantQueryParam
+    public class QueryParameters
     {
         [FromQuery(Name = "first_name")]
         public string FirstName { get; set; }

--- a/AcademyResidentInformationApi/V1/Boundary/Responses/TaxPayerInformationList.cs
+++ b/AcademyResidentInformationApi/V1/Boundary/Responses/TaxPayerInformationList.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace AcademyResidentInformationApi.V1.Boundary.Responses
+{
+    public class TaxPayerInformationList
+    {
+        public List<TaxPayerInformationResponse> TaxPayers { get; set; }
+    }
+}

--- a/AcademyResidentInformationApi/V1/Controllers/ClaimantsController.cs
+++ b/AcademyResidentInformationApi/V1/Controllers/ClaimantsController.cs
@@ -1,7 +1,7 @@
-using AcademyResidentInformationApi.V1.UseCase.Interfaces;
-using Microsoft.AspNetCore.Mvc;
 using AcademyResidentInformationApi.V1.Boundary.Requests;
 using AcademyResidentInformationApi.V1.Domain;
+using AcademyResidentInformationApi.V1.UseCase.Interfaces;
+using Microsoft.AspNetCore.Mvc;
 
 namespace AcademyResidentInformationApi.V1.Controllers
 {
@@ -21,11 +21,11 @@ namespace AcademyResidentInformationApi.V1.Controllers
         }
 
         [HttpGet]
-        public IActionResult ListContacts([FromQuery] ClaimantQueryParam cqp, string cursor = null, int? limit = 20)
+        public IActionResult ListContacts([FromQuery] QueryParameters qp, string cursor = null, int? limit = 20)
         {
             try
             {
-                return Ok(_getAllClaimantsUseCase.Execute(cqp, cursor, (int) limit));
+                return Ok(_getAllClaimantsUseCase.Execute(qp, cursor, (int) limit));
             }
             catch (InvalidQueryParameterException e)
             {

--- a/AcademyResidentInformationApi/V1/Controllers/TaxPayersController.cs
+++ b/AcademyResidentInformationApi/V1/Controllers/TaxPayersController.cs
@@ -1,8 +1,8 @@
-using AcademyResidentInformationApi.V1.UseCase.Interfaces;
-using Microsoft.AspNetCore.Mvc;
 using AcademyResidentInformationApi.V1.Boundary.Requests;
 using AcademyResidentInformationApi.V1.Domain;
 using AcademyResidentInformationApi.V1.UseCase;
+using AcademyResidentInformationApi.V1.UseCase.Interfaces;
+using Microsoft.AspNetCore.Mvc;
 
 namespace AcademyResidentInformationApi.V1.Controllers
 {
@@ -13,16 +13,19 @@ namespace AcademyResidentInformationApi.V1.Controllers
     public class TaxPayersController : BaseController
     {
         private readonly IGetTaxPayerByIdUseCase _getTaxPayerByIdUseCase;
+        private readonly IGetAllTaxPayersUseCase _getAllTaxPayersUseCase;
 
-        public TaxPayersController(IGetTaxPayerByIdUseCase getTaxPayerByIdUseCase)
+        public TaxPayersController(IGetAllTaxPayersUseCase getAllTaxPayersUseCase, IGetTaxPayerByIdUseCase getTaxPayerByIdUseCase)
         {
+            _getAllTaxPayersUseCase = getAllTaxPayersUseCase;
             _getTaxPayerByIdUseCase = getTaxPayerByIdUseCase;
         }
 
         [HttpGet]
-        public IActionResult ListTaxPayers()
+        public IActionResult ListTaxPayers([FromQuery] QueryParameters qp)
         {
-            return Ok();
+            var record = _getAllTaxPayersUseCase.Execute(qp);
+            return Ok(record);
         }
 
         [HttpGet]

--- a/AcademyResidentInformationApi/V1/Factories/ResponseFactory.cs
+++ b/AcademyResidentInformationApi/V1/Factories/ResponseFactory.cs
@@ -48,6 +48,11 @@ namespace AcademyResidentInformationApi.V1.Factories
             };
         }
 
+        public static List<TaxPayerInformationResponse> ToResponse(this IEnumerable<TaxPayerInformation> taxPayers)
+        {
+            return taxPayers.Select(tp => tp.ToResponse()).ToList();
+        }
+
         private static AddressResponse ToResponse(this Address domainAddress)
         {
             return new AddressResponse()

--- a/AcademyResidentInformationApi/V1/Gateways/IAcademyGateway.cs
+++ b/AcademyResidentInformationApi/V1/Gateways/IAcademyGateway.cs
@@ -10,6 +10,7 @@ namespace AcademyResidentInformationApi.V1.Gateways
         List<ClaimantInformation> GetAllClaimants(Cursor cursor, int limit, string firstname = null,
             string lastname = null, string postcode = null, string address = null);
         ClaimantInformation GetClaimantById(int claimId, int personRef);
+        List<TaxPayerInformation> GetAllTaxPayers(string firstname = null, string lastname = null, string address = null, string postcode = null);
         TaxPayerInformation GetTaxPayerById(int accountRef);
     }
 

--- a/AcademyResidentInformationApi/V1/Infrastructure/AcademyContext.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/AcademyContext.cs
@@ -48,6 +48,14 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
                     x.ClaimId,
                     x.HouseId
                 });
+
+            modelBuilder.Entity<Email>()
+                .HasKey(email => new
+                {
+                    email.PersonType,
+                    email.PersonTypeSequenceNumber,
+                    email.ReferenceId
+                });
         }
     }
 }

--- a/AcademyResidentInformationApi/V1/Infrastructure/Email.cs
+++ b/AcademyResidentInformationApi/V1/Infrastructure/Email.cs
@@ -6,9 +6,14 @@ namespace AcademyResidentInformationApi.V1.Infrastructure
     [Table("syemail", Schema = "dbo")]
     public class Email
     {
-        [Key]
         [Column("reference_id")]
         public int ReferenceId { get; set; }
+
+        [Column("person_type")]
+        public short PersonType { get; set; }
+
+        [Column("person_type_seq_no")]
+        public short PersonTypeSequenceNumber { get; set; }
 
         [Column("email_addr")]
         [MaxLength(128)]

--- a/AcademyResidentInformationApi/V1/UseCase/GetAllClaimantsUseCase.cs
+++ b/AcademyResidentInformationApi/V1/UseCase/GetAllClaimantsUseCase.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Linq;
+using AcademyResidentInformationApi.V1.Boundary.Requests;
 using AcademyResidentInformationApi.V1.Boundary.Responses;
+using AcademyResidentInformationApi.V1.Domain;
 using AcademyResidentInformationApi.V1.Factories;
 using AcademyResidentInformationApi.V1.Gateways;
 using AcademyResidentInformationApi.V1.UseCase.Interfaces;
-using AcademyResidentInformationApi.V1.Boundary.Requests;
-using AcademyResidentInformationApi.V1.Domain;
 
 namespace AcademyResidentInformationApi.V1.UseCase
 {
@@ -19,17 +19,17 @@ namespace AcademyResidentInformationApi.V1.UseCase
             _validatePostcode = new ValidatePostcode();
         }
 
-        public ClaimantInformationList Execute(ClaimantQueryParam cqp, string cursor, int limit)
+        public ClaimantInformationList Execute(QueryParameters qp, string cursor, int limit)
         {
             //Check if the query parameter includes a value for postcode
-            if (!string.IsNullOrWhiteSpace(cqp.Postcode))
-                CheckPostCodeValid(cqp.Postcode);
+            if (!string.IsNullOrWhiteSpace(qp.Postcode))
+                CheckPostCodeValid(qp.Postcode);
 
             limit = limit < 10 ? 10 : limit;
             limit = limit > 100 ? 100 : limit;
 
 
-            var claimants = _academyGateway.GetAllClaimants(DeconstructCursor(cursor), limit, cqp.FirstName, cqp.LastName, cqp.Postcode, cqp.Address);
+            var claimants = _academyGateway.GetAllClaimants(DeconstructCursor(cursor), limit, qp.FirstName, qp.LastName, qp.Postcode, qp.Address);
 
             var lastClaimant = claimants.LastOrDefault();
             var nextCursor = claimants.Count == limit ? $"{lastClaimant.ClaimId}-{lastClaimant.HouseId}-{lastClaimant.MemberId}" : "";

--- a/AcademyResidentInformationApi/V1/UseCase/GetAllTaxPayersUseCase.cs
+++ b/AcademyResidentInformationApi/V1/UseCase/GetAllTaxPayersUseCase.cs
@@ -1,0 +1,26 @@
+using AcademyResidentInformationApi.V1.Boundary.Requests;
+using AcademyResidentInformationApi.V1.Boundary.Responses;
+using AcademyResidentInformationApi.V1.Factories;
+using AcademyResidentInformationApi.V1.Gateways;
+using AcademyResidentInformationApi.V1.UseCase.Interfaces;
+
+namespace AcademyResidentInformationApi.V1.UseCase
+{
+    public class GetAllTaxPayersUseCase : IGetAllTaxPayersUseCase
+    {
+        private readonly IAcademyGateway _academyGateway;
+        public GetAllTaxPayersUseCase(IAcademyGateway academyGateway)
+        {
+            _academyGateway = academyGateway;
+        }
+
+        public TaxPayerInformationList Execute(QueryParameters qp)
+        {
+            var taxPayers = _academyGateway.GetAllTaxPayers(qp.FirstName, qp.LastName, qp.Postcode, qp.Address);
+            return new TaxPayerInformationList
+            {
+                TaxPayers = taxPayers.ToResponse()
+            };
+        }
+    }
+}

--- a/AcademyResidentInformationApi/V1/UseCase/Interfaces/IGetAllTaxPayersUseCase.cs
+++ b/AcademyResidentInformationApi/V1/UseCase/Interfaces/IGetAllTaxPayersUseCase.cs
@@ -1,12 +1,10 @@
-
 using AcademyResidentInformationApi.V1.Boundary.Requests;
 using AcademyResidentInformationApi.V1.Boundary.Responses;
 
 namespace AcademyResidentInformationApi.V1.UseCase.Interfaces
 {
-    public interface IGetAllClaimantsUseCase
+    public interface IGetAllTaxPayersUseCase
     {
-        ClaimantInformationList Execute(QueryParameters qp, string cursor, int limit);
+        TaxPayerInformationList Execute(QueryParameters qp);
     }
-
 }

--- a/AcademyResidentInformationApi/V1/UseCase/ValidatePostcode.cs
+++ b/AcademyResidentInformationApi/V1/UseCase/ValidatePostcode.cs
@@ -1,5 +1,5 @@
-using AcademyResidentInformationApi.V1.UseCase.Interfaces;
 using System.Text.RegularExpressions;
+using AcademyResidentInformationApi.V1.UseCase.Interfaces;
 
 
 namespace AcademyResidentInformationApi.V1.UseCase


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-275

## Describe this PR

### *When I call the Academy Resident Contact Information platform API, I want the data to be returned so that I can use it in my own service.*

The returned data should be in the format listed in the Swagger documentation (created in ticket https://hackney.atlassian.net/browse/PA-274 ) 

### *What changes have we introduced*

- GetAllTaxPayers method created in AcademyCouncilTaxGateway
- GetAllTaxPayersUseCase implemented
- ClaimantQueryParam genericised to be used for claimants and tax payers
- TaxPayerInformationList response created for future pagination
- ToResponse method implemented for TaxPayerInformationList
- List endpoint implemented in TaxPayersController
- E2E integration testing complete

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Next ticket related will be to add pagination