### PR TITLE
Add manual permits before terraform and serverless deployments on all environments.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,10 +260,17 @@ workflows:
           filters:
             branches:
               only: master
+      - permit-staging-terraform-release:
+          type: approval
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
-              - build-and-test
+              - permit-staging-terraform-release
           filters:
              branches:
                only: master
@@ -273,9 +280,16 @@ workflows:
           filters:
             branches:
               only: master
-      - migrate-database-staging:
+      - permit-staging-deployment:
+          type: approval
           requires:
             - terraform-init-and-apply-to-staging
+          filters:
+            branches:
+              only: development
+      - migrate-database-staging:
+          requires:
+            - permit-staging-deployment
             - assume-role-staging
           filters:
             branches:
@@ -283,7 +297,7 @@ workflows:
       - deploy-to-staging:
           requires:
             - assume-role-staging
-            - migrate-database-staging
+            - permit-staging-deployment
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,13 @@ workflows:
       - permit-production-terraform-release:
           type: approval
           requires:
-            - deploy-to-staging
+            - deploy-to-staging- permit-staging-deployment:
+          type: approval
+          requires:
+            - terraform-init-and-apply-to-staging
+          filters:
+            branches:
+              only: master
       - assume-role-production:
           context: api-assume-role-production-context
           requires:
@@ -318,23 +324,23 @@ workflows:
           filters:
             branches:
               only: master
-      - migrate-database-production:
+      - permit-production-deployment:
+          type: approval
           requires:
             - terraform-init-and-apply-to-production
-            - assume-role-production
           filters:
             branches:
               only: master
-      - permit-production-release:
-          type: approval
+      - migrate-database-production:
           requires:
+            - permit-production-deployment
             - assume-role-production
           filters:
             branches:
               only: master
       - deploy-to-production:
           requires:
-            - permit-production-release
+            - permit-production-deployment
             - assume-role-production
             - migrate-database-production
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,7 @@ workflows:
             - terraform-init-and-apply-to-staging
           filters:
             branches:
-              only: development
+              only: master
       - migrate-database-staging:
           requires:
             - permit-staging-deployment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,10 +213,17 @@ workflows:
     jobs:
       - check-code-formatting
       - build-and-test
+      - permit-development-terraform-release:
+          type: approval
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: development
       - assume-role-development:
           context: api-assume-role-development-context
           requires:
-            - build-and-test
+            - permit-development-terraform-release
           filters:
             branches:
               only: development
@@ -226,15 +233,23 @@ workflows:
           filters:
             branches:
               only: development
-      - migrate-database-development:
+      - permit-development-deployment:
+          type: approval
           requires:
             - terraform-init-and-apply-to-development
+          filters:
+            branches:
+              only: development
+      - migrate-database-development:
+          requires:
+            - permit-development-deployment
             - assume-role-development
           filters:
             branches:
               only: development
       - deploy-to-development:
           requires:
+            - permit-development-deployment
             - assume-role-development
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,61 +209,58 @@ jobs:
           stage: "production"
 
 workflows:
-  check-and-deploy-development:
+  check-and-deploy-staging-and-production:
     jobs:
       - check-code-formatting
-      - build-and-test
+      - build-and-test:
+          filters:
+            branches:
+              only: master
       - permit-development-terraform-release:
           type: approval
           requires:
             - build-and-test
           filters:
             branches:
-              only: development
+              only: master
       - assume-role-development:
           context: api-assume-role-development-context
           requires:
             - permit-development-terraform-release
           filters:
             branches:
-              only: development
+              only: master
       - terraform-init-and-apply-to-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: development
+              only: master
       - permit-development-deployment:
           type: approval
           requires:
             - terraform-init-and-apply-to-development
           filters:
             branches:
-              only: development
+              only: master
       - migrate-database-development:
           requires:
             - permit-development-deployment
             - assume-role-development
           filters:
             branches:
-              only: development
+              only: master
       - deploy-to-development:
           requires:
             - permit-development-deployment
             - assume-role-development
           filters:
             branches:
-              only: development
-  check-and-deploy-staging-and-production:
-    jobs:
-      - build-and-test:
-          filters:
-            branches:
               only: master
       - permit-staging-terraform-release:
           type: approval
           requires:
-            - build-and-test
+            - deploy-to-development
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,10 +301,7 @@ workflows:
       - permit-production-terraform-release:
           type: approval
           requires:
-            - deploy-to-staging- permit-staging-deployment:
-          type: approval
-          requires:
-            - terraform-init-and-apply-to-staging
+            - deploy-to-staging
           filters:
             branches:
               only: master


### PR DESCRIPTION
# What:
 - Added manual permit buttons before deploying terraform infrastructure changes to all environments.
 - Added manual permit buttons before deploying serverless infrastructure changes to all environments.
 - Merge the `development` workflow with the `staging/production` workflow.

# Why:
 - To prevent unintended deployments upon merges to main branches whilst preparing repository for the decommissioning work.
 - The workflow change is because the `development` branch and the environment have been gotten rid of, however, `DevelopmentAPIs` environment was not cleaned up properly _(meaning further work is needed)_.

# Notes:
 - The pipeline is failing because no key has been configured yet within the CCI options. This is irrelevant now, and will be addressed later.