### PR TITLE
Remove CODEOWNERs as the application is no longer owned by anyone.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty


### PR DESCRIPTION
# What:
 - Remove a `CODEOWNERS` file.

# Why:
 - The application has no owners, and is not in use. Its database is up for decommissioning.
 - Need to remove `CODEOWNERS` to unblock the repository so a full decommissioning could take place.

# Notes:
 - The pipeline currently fails due to missing SSH key. That will get addressed later on. For now, the pipeline failure is being counted on to prevent staging deployment from happening upon this PR's merge.
 - The `development` branch doesn't exist anymore, hence merge to `master`.
