### PR TITLE
Add feature workflow with Terraform preview steps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,17 @@ workflows:
           filters:
             branches:
               ignore: master
-
+      - assume-role-production:
+          context: api-assume-role-production-context
+          filters:
+             branches:
+               ignore: master
+      - terraform-preview-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              ignore: master
 
   check-and-deploy-staging-and-production:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,19 @@ workflows:
           filters:
             branches:
               ignore: master
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          filters:
+             branches:
+               ignore: master
+      - terraform-preview-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              ignore: master
+
+
   check-and-deploy-staging-and-production:
     jobs:
       - check-code-formatting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,21 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: 'production'
+  terraform-preview-development:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: 'development'
+  terraform-preview-staging:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: 'staging'
+  terraform-preview-production:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: 'production'
   deploy-to-development:
     executor: docker-dotnet
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,21 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
+  terraform-preview:
+    description: "Preview terraform configuration changes"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: terraform preview
   deploy-lambda:
     description: "Deploys API via Serverless"
     parameters:
@@ -166,7 +181,7 @@ jobs:
     executor: docker-terraform
     steps:
       - terraform-init-then-apply:
-          environment: development
+          environment: 'development'
   terraform-init-and-apply-to-staging:
     executor: docker-terraform
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,19 @@ jobs:
           stage: "production"
 
 workflows:
+  preview-terraform-changes:
+    jobs:
+      - assume-role-development:
+          context: api-assume-role-development-context
+          filters:
+            branches:
+              ignore: master
+      - terraform-preview-development:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              ignore: master
   check-and-deploy-staging-and-production:
     jobs:
       - check-code-formatting


### PR DESCRIPTION
# What:
 - Created the feature branch workflow.
 - Added Terraform configuration changes preview steps to that workflow for each environment.

# Why:
 - To check/debug the Terraform is properly configured to start decommissioning the infrastructure.
 - To be able to preview the Terraform changes without the need to merge the PR with the given changes.

# Notes:
 - The red 'X' is shown next to the commits because the expired SSH hasn't been addressed yet. It will get addressed for the last commit.
 - Edit: fixed the SSH, but now the formatter's options are deprecated. Will remove the formatting check with the build within the subsequent PR as the application is not going to be deployed again.