### PR TITLE
Clean up and speed up the pipeline.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,6 @@ workflows:
 
   check-and-deploy-staging-and-production:
     jobs:
-      - check-code-formatting
       - build-and-test:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,13 +309,6 @@ workflows:
           filters:
             branches:
               only: master
-      - migrate-database-development:
-          requires:
-            - permit-development-deployment
-            - assume-role-development
-          filters:
-            branches:
-              only: master
       - deploy-to-development:
           requires:
             - permit-development-deployment
@@ -347,13 +340,6 @@ workflows:
           type: approval
           requires:
             - terraform-init-and-apply-to-staging
-          filters:
-            branches:
-              only: master
-      - migrate-database-staging:
-          requires:
-            - permit-staging-deployment
-            - assume-role-staging
           filters:
             branches:
               only: master
@@ -391,18 +377,10 @@ workflows:
           filters:
             branches:
               only: master
-      - migrate-database-production:
-          requires:
-            - permit-production-deployment
-            - assume-role-production
-          filters:
-            branches:
-              only: master
       - deploy-to-production:
           requires:
             - permit-production-deployment
             - assume-role-production
-            - migrate-database-production
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,17 +102,6 @@ commands:
             sls deploy --stage <<parameters.stage>> --conceal
 
 jobs:
-  build-and-test:
-    executor: docker-python
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: build
-          command: docker-compose build academy-api-test
-      - run:
-          name: Run tests
-          command: docker-compose run academy-api-test
   assume-role-development:
     executor: docker-python
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,21 +222,6 @@ jobs:
     steps:
       - deploy-lambda:
           stage: 'production'
-  migrate-database-development:
-    executor: docker-dotnet
-    steps:
-      - migrate-database:
-          stage: "development"
-  migrate-database-staging:
-    executor: docker-dotnet
-    steps:
-      - migrate-database:
-          stage: "staging"
-  migrate-database-production:
-    executor: docker-dotnet
-    steps:
-      - migrate-database:
-          stage: "production"
 
 workflows:
   preview-terraform-changes:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,14 +213,8 @@ workflows:
 
   check-and-deploy-staging-and-production:
     jobs:
-      - build-and-test:
-          filters:
-            branches:
-              only: master
       - permit-development-terraform-release:
           type: approval
-          requires:
-            - build-and-test
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,46 +100,7 @@ commands:
           command: |
             cd ./AcademyResidentInformationApi/
             sls deploy --stage <<parameters.stage>> --conceal
-  migrate-database:
-    description: "Migrate database"
-    parameters:
-      stage:
-        type: string
-    steps:
-      - *attach_workspace
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Install Unzip
-          command: apt-get update && apt-get install unzip
-      - run:
-          name: Install AWS CLI
-          command: |
-            curl -L -o awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-            unzip awscliv2.zip
-            ./aws/install
-      - run:
-          name: Install Session Manager plugin
-          command: |
-            curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
-            dpkg -i session-manager-plugin.deb
-      - run:
-          name: Install dotnet ef core
-          command: dotnet tool install dotnet-ef --tool-path ./dotnet-ef-local/
-      - run:
-          name: SSH into RDS and migrate database
-          command: |
-            aws ssm get-parameter --name "/platform-apis-jump-box-pem-key" --output text --query Parameter.Value > ./private-key.pem
-            chmod 400 ./private-key.pem
-            HOST=$(aws ssm get-parameter --name /academy-api/<<parameters.stage>>/postgres-hostname --query Parameter.Value)
-            PORT=$(aws ssm get-parameter --name /academy-api/<<parameters.stage>>/postgres-port --query Parameter.Value)
-            INSTANCE_NAME=$(aws ssm get-parameter --name /platform-apis-jump-box-instance-name --query Parameter.Value)
-            ssh -4 -i ./private-key.pem -Nf -M -L 5432:${HOST//\"}:${PORT//\"} -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -o "ServerAliveInterval=1" -o "ExitOnForwardFailure=yes" -o ProxyCommand="aws ssm start-session --target %h --document AWS-StartSSHSession --parameters portNumber=%p --region=eu-west-2" ec2-user@${INSTANCE_NAME//\"}
-            PASSWORD=$(aws ssm get-parameter --name /academy-api/<<parameters.stage>>/postgres-password --query Parameter.Value)
-            USERNAME=$(aws ssm get-parameter --name /academy-api/<<parameters.stage>>/postgres-username --query Parameter.Value)
-            CONN_STR="Host=localhost;Password=${PASSWORD};Port=5432;Username=${USERNAME};Database=academy_mirror;CommandTimeout=120;"
-            cd ./AcademyResidentInformationApi/
-            CONNECTION_STRING=${CONN_STR} ./../dotnet-ef-local/dotnet-ef database update
+
 jobs:
   check-code-formatting:
     executor: docker-dotnet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,16 +102,6 @@ commands:
             sls deploy --stage <<parameters.stage>> --conceal
 
 jobs:
-  check-code-formatting:
-    executor: docker-dotnet
-    steps:
-      - checkout
-      - run:
-          name: Install dotnet format
-          command: dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - run:
-          name: Run formatter check
-          command: ./dotnet-format-local/dotnet-format --dry-run --check
   build-and-test:
     executor: docker-python
     steps:


### PR DESCRIPTION
# What:
 - Removed the code formatting checks.
 - Removed the build and test checks.
 - Removed the database migration steps.

# Why:
 - Everything is getting decommissioned & the repository will get archived. So none of these checks matter for the purposes of infrastructure retirement.

# Notes:
 - The `staging` and `production` Terraform previews are "failing" because the VPC were renamed since the configuration was written, and as such TF is unable to find VPC via their old name. No need to fix this, as it's not relevant for the purposes of resource retirement that will soon follow suite.