### PR TITLE
Retire `DevelopmentAPIs` environement's serverless resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,12 +88,6 @@ commands:
           name: Install serverless CLI
           command: npm i -g serverless
       - run:
-          name: Build lambda
-          command: |
-            cd ./AcademyResidentInformationApi/
-            chmod +x ./build.sh
-            ./build.sh
-      - run:
           name: Deploy lambda
           command: |
             cd ./AcademyResidentInformationApi/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Deploy lambda
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,12 @@ commands:
           name: Deploy lambda
           command: |
             cd ./AcademyResidentInformationApi/
-            sls deploy --stage <<parameters.stage>> --conceal
+            if [ "<<parameters.stage>>" = "development" ]
+            then
+              sls remove --stage <<parameters.stage>> --verbose
+            else
+              sls deploy --stage <<parameters.stage>> --conceal
+            fi 
 
 jobs:
   assume-role-development:


### PR DESCRIPTION
# What:
 - Upgrade pipeline's node to v14.
 - Cap serverless major version to v3.
 - Remove the `development` environment's resources.

# Why:
 -  Node.js v14 is the minimum newer serverless versions require.
 - Capped serverless due to v4 requiring a paid license.
 - The `development` environment within the `DevelopmentAPIs` account has long been retired, however, some resources are left lingering. This PR will put them to rest.

# Notes:
 - The `staging` and `production` previews are failing due to renamed VPC. This is of no consequence right now.