### PR TITLE
Resolve missing parameter key + Bump node to dodge the depreciation wait timer.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_14.x | bash -
+            curl -sL https://deb.nodesource.com/setup_16.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/AcademyResidentInformationApi/serverless.yml
+++ b/AcademyResidentInformationApi/serverless.yml
@@ -77,6 +77,12 @@ resources:
                   Resource: "*"
 custom:
   vpc:
+    development:
+      securityGroupIds:
+        - sg-0b36c6cf8baa1d931
+      subnetIds:
+        - subnet-0deabb5d8fb9c3446
+        - subnet-000b89c249f12a8ad
     staging:
       securityGroupIds:
         - sg-0436b39b527a8ef07


### PR DESCRIPTION
# What:
 - Bump pipeline's Node.js to V16.
 - Added the `DevelopmentAPIs` VPC variables.

# Why:
 - Despite v14 being the minimum new sls expects, it is already deprecated and as such thread sleeps for 20 + 60 secs before continuing from the deprecation warning.
 - Added development VPC variables so that YAML would have something to resolve to to avoid the missing key error. There's an alternative away to solve this, but I'd prefer to give it a go with minimal serverless YAML changes.