### PR TITLE
Retire `StagingAPIs` serverless resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_16.x | bash -
+            curl -sL https://deb.nodesource.com/setup_18.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ commands:
           no_output_timeout: 45m
           command: |
             cd ./AcademyResidentInformationApi/
-            if [ "<<parameters.stage>>" = "environment" ]
+            if [ "<<parameters.stage>>" = "staging" ]
             then
               sls remove --stage <<parameters.stage>> --verbose
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ commands:
           name: get and init
       - run:
           name: apply
+          no_output_timeout: 45m
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
@@ -89,6 +90,7 @@ commands:
           command: npm i -g serverless@^3
       - run:
           name: Deploy lambda
+          no_output_timeout: 45m
           command: |
             cd ./AcademyResidentInformationApi/
             if [ "<<parameters.stage>>" = "environment" ]


### PR DESCRIPTION
# What:
 - Trigger the `StagingAPIs` environment serverless resource retirement.
 - Extend the infrastructure deployment timeout within the CircleCI.
 - Bump node to v18.

# Why:
 - Environment is no longer needed with the database having been decommissioned in PR #66 .
 - Increased timeout to reduce the likelihood of production infrastructure retirement failure as the databases seem to take a while to get decommissioned.
 - Bump node from v16 to v18 to reduce the text clutter within the pipeline.

# Notes:
 - The `production` TF preview will be failing due to renamed VPC, this will get addressed the following day as we get to retiring production resources.