### PR TITLE
Retire `ProductionAPIs` terraform managed resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
+  aws-cli: circleci/aws-cli@5.1.0
 
 executors:
   docker-python:
@@ -98,7 +99,17 @@ commands:
               sls remove --stage <<parameters.stage>> --verbose
             else
               sls deploy --stage <<parameters.stage>> --conceal
-            fi 
+            fi
+  delete-rds:
+    description: "Removes floating AWS RDS instance that TF can't reach anymore"
+    steps:
+      - *attach_workspace
+      - aws-cli/install
+      - run:
+          name: remove floating rds
+          no_output_timeout: 45m
+          command: |
+            aws rds delete-db-instance --db-instance-identifier 'academy-mirror-db-production' --skip-final-snapshot
 
 jobs:
   assume-role-production:
@@ -121,6 +132,10 @@ jobs:
     steps:
       - deploy-lambda:
           stage: 'production'
+  remove-prod-rds:
+    executor: aws-cli/default
+    steps:
+     - delete-rds
 
 workflows:
   preview-terraform-changes:
@@ -151,9 +166,15 @@ workflows:
           filters:
             branches:
               only: master
-      - terraform-init-and-apply-to-production:
+      - remove-prod-rds:
           requires:
               - permit-production-terraform-release
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-production:
+          requires:
+              - remove-prod-rds
           filters:
             branches:
               only: master

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -79,32 +79,3 @@ data "aws_ssm_parameter" "academy_hostname" {
 data "aws_ssm_parameter" "academy_postgres_hostname" {
    name = "/academy-api/production/postgres-hostname"
 }
-module "dms_setup_production" {
-  source = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_setup_existing_instance"
-  environment_name = "production"
-  project_name = "resident-information-apis" 
-  //target db for dms endpoint
-  target_db_name = "academy_mirror" 
-  target_endpoint_identifier = "target-academy-endpoint" 
-  target_db_engine_name = "postgres"
-  target_db_port = 5100
-  target_db_username = data.aws_ssm_parameter.academy_postgres_username.value
-  target_db_password = data.aws_ssm_parameter.academy_postgres_db_password.value
-  target_db_server = data.aws_ssm_parameter.academy_postgres_hostname.value 
-  target_endpoint_ssl_mode = "none"
-  //source db for dms endpoint
-  source_db_name = "HBCTLIVEDB" //the name of the source (on-prem) database
-  source_endpoint_identifier = "source-academy-endpoint" //unique identifier (name) you give for the endpoint to be created
-  source_db_engine_name = "sqlserver"
-  source_db_port = 1433
-  source_db_username = data.aws_ssm_parameter.academy_username.value
-  source_db_password = data.aws_ssm_parameter.academy_password.value
-  source_db_server = data.aws_ssm_parameter.academy_hostname.value 
-  source_endpoint_ssl_mode = "none"
-  //dms task set up
-  migration_type = "full-load" 
-  replication_task_indentifier = "academy-api-dms-task" 
-  task_settings = file("${path.module}/task_settings.json") 
-  task_table_mappings = file("${path.module}/selection_rules.json")
-  replication_instance_arn = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:65CJ5HE2DMCUW5X6EPKTKUDVWA"
-}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -45,27 +45,6 @@ data "aws_subnet_ids" "production" {
    name = "/academy-api/production/postgres-username"
  }
 
-module "postgres_db_production" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name = "production"
-  vpc_id = data.aws_vpc.production_vpc.id
-  db_identifier = "academy-mirror-db"
-  db_name = "academy_mirror"
-  db_port  = 5100
-  subnet_ids = data.aws_subnet_ids.production.ids
-  db_engine = "postgres"
-  db_engine_version = "11.1"
-  db_instance_class = "db.t2.micro"
-  db_allocated_storage = 20
-  maintenance_window = "sun:10:00-sun:10:30"
-  db_username = data.aws_ssm_parameter.academy_postgres_username.value
-  db_password = data.aws_ssm_parameter.academy_postgres_db_password.value
-  storage_encrypted = false
-  multi_az = true //only true if production deployment
-  publicly_accessible = false
-  project_name = "platform apis"
-}
-
 /*      DMS SET UP         */
 data "aws_ssm_parameter" "academy_username" {
    name = "/academy/reporting-server/username"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -11,11 +11,6 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-locals {
-   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
 
 terraform {
   backend "s3" {
@@ -24,37 +19,4 @@ terraform {
     region  = "eu-west-2"
     key     = "services/academy-resident-information-api/state"
   }
-}
-data "aws_vpc" "production_vpc" {
-  tags = {
-    Name = "vpc-production-apis-production"
-  }
-}
-data "aws_subnet_ids" "production" {
-  vpc_id = data.aws_vpc.production_vpc.id
- filter {
-    name   = "tag:Type"
-    values = ["private"] # insert values here
-  }
-}
-
- data "aws_ssm_parameter" "academy_postgres_db_password" {
-   name = "/academy-api/production/postgres-password"
- }
-  data "aws_ssm_parameter" "academy_postgres_username" {
-   name = "/academy-api/production/postgres-username"
- }
-
-/*      DMS SET UP         */
-data "aws_ssm_parameter" "academy_username" {
-   name = "/academy/reporting-server/username"
-}
-data "aws_ssm_parameter" "academy_password" {
-   name = "/academy/reporting-server/password"
-}
-data "aws_ssm_parameter" "academy_hostname" {
-   name = "/academy/reporting-server/hostname"
-}
-data "aws_ssm_parameter" "academy_postgres_hostname" {
-   name = "/academy-api/production/postgres-hostname"
 }


### PR DESCRIPTION
# What:
 - Remove `ProductionAPIs` AWS resource definitions specified within the production Terraform file.
 - Add an AWS RDS postgres instance removal command.

# Why:
 - To trigger the clean up of these unused resources.
 - Based on the connection metrics, the database appears to have only been used by canary lambdas for as far as the monitoring can show.
 - The DMS task related to the database has been manually removed long ago, so there's no need to keep the remnant endpoints.

# Notes:
## Main:
 - The database snapshot was taken under the name of: `academy-mirror-db-production-not-used-in-possibly-15-months-snapshot` _(**Sc3**)_.
 - The database usage monitoring extends to the last 15 months. We know that these traffic fluctuations _(**Sc1**)_ from the baseline connection are canary lambdas because the academy API endpoint call logs _(**Tx1**)_ match up exactly with the 4 canary lambdas deployed  _(**Sc7**)_. Additionally, there's always just 1 extra connection on top of the baseline one _(**Sc2**)_. These same endpoints get called 24/7 _(**Sc6**)_ going months back.
 - Also, an agreed by the team test was performed to check whether the baseline connection implies any usage or not - the database was stopped for a week starting 25th July. No complaints were raised until now. As per team's definition of no usage - we're good to decommission it.
 - The database on the cloud seems to have been renamed compared to its Terraform (or tfstate file) definition. As such, Terraform does not see it as existing, so it will need to be clean up manually.
 - The DMS task and whatever instance involved appear to have been decommissioned manually via the AWS UI console as these resources don't appear to exist _(**Sc4**)_ anymore even before these changes. The only remnants left are the academy source and target DMS endpoints _(**Sc5**)_ that the terraform will clean up.

## Removed resources:
### Terraform removes:
```tf
module.postgres_db_production.aws_db_subnet_group.db_subnets ("academy_mirror-db-subnet-production") will be destroyed
module.dms_setup_production.module.source_dms_endpoint.aws_dms_endpoint.dms_endpoint ("target-academy-endpoint") will be destroyed
module.dms_setup_production.module.target_dms_endpoint.aws_dms_endpoint.dms_endpoint ("source-academy-endpoint") will be destroyed
module.postgres_db_production.module.db_security_group.aws_security_group.lbh_db_traffic ("allow_academy_mirror_db_traffic") will be destroyed
```

### Script removes:
 - The `academy-mirror-db-production` AWS RDS postgres instance on `ProductionAPIs` account.

# References
## `Tx1.` List of academy API endpoints called by canaries:
Notice that these endpoint calls from the `academy-api-production` API match up with the names of the canary lambdas on **Sc7**.
```py
Request starting  GET https://6fckwzu0r3.execute-api.eu-west-2.amazonaws.com/production/api/v1/claimants  0
Request starting  GET https://6fckwzu0r3.execute-api.eu-west-2.amazonaws.com/production/api/v1/claimants/claim/1/person/2  0
Request starting  GET https://6fckwzu0r3.execute-api.eu-west-2.amazonaws.com/production/api/v1/tax-payers/30841148  0
Request starting  GET https://6fckwzu0r3.execute-api.eu-west-2.amazonaws.com/production/api/v1/tax-payers  0
```

## Screenshots
### RDS Database
| `Sc1.` Canary connections noise 15 months | `Sc2.` Max 2 connections at a time |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c696a7b4-79f8-4fe0-bda1-ddd427ca03f2) | ![image](https://github.com/user-attachments/assets/d24d0b36-584c-4122-bca9-625d408de4c2) |

| `Sc3.` Database's manual snapshot. |
| --- |
|  ![image](https://github.com/user-attachments/assets/e1df453c-5b7f-412c-b53a-6d27052abdd9) |


### DMS setup
| `Sc4.` The `academy-api-dms-task` no longer exists | `Sc5.` Remaining academy DMS tasks endpoints |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/a893d2f9-24a1-4110-a2e1-b8deedd8b947) | ![image](https://github.com/user-attachments/assets/15d76e87-c1fd-4484-bc40-fcfcb40e4c79) |

### Canaries
| `Sc6.` Academy API getting called 24/7 | `Sc7.` List of academy canaries |
| --- | --- |
|  ![image](https://github.com/user-attachments/assets/9bc6d83a-0253-410f-ac9a-206b8b82e89c) | ![image](https://github.com/user-attachments/assets/5c46c019-81aa-4af4-9204-cf3c53bcd6d9) |
