### PR TITLE
Retire `ProductionAPIs` serverless managed resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ commands:
           no_output_timeout: 45m
           command: |
             cd ./AcademyResidentInformationApi/
-            if [ "<<parameters.stage>>" = "environment" ]
+            if [ "<<parameters.stage>>" = "production" ]
             then
               sls remove --stage <<parameters.stage>> --verbose
             else


### PR DESCRIPTION
# What:
 - Make the pipeline trigger the removal of serverless academy resources on `ProductionAPIs`.

# Why:
 - Based on the logs, the API is only being consumed by the canary lambdas.
 - The database to which this API connects to is about to get decommissioned, so the API will become irrelevant.

# Notes:
 - Serverless resources need to be destroyed before the Terraform ones to avoid potential ScG or SubG dependency conflicts _(where possible)_.
 - For more information on the API and the database usage see PR #71 .
 - The pipeline fails because of the renamed production VPC, the PR linked above finally resolves the issue. The issue does not matter for this PR.